### PR TITLE
F/megakey errors

### DIFF
--- a/elements/keys.tex
+++ b/elements/keys.tex
@@ -8,9 +8,20 @@
 %
 %    \megakey{Shift}
 % 
+%
+% If you get warnings on special characters, mathematical characters etc, use $, eg:
+%
+%    \megakey{$\leftarrow$}
+%
 % Other sizes are supported, as part of tcolorbox: http://mirror.aarnet.edu.au/pub/CTAN/macros/latex/contrib/tcolorbox/tcolorbox.pdf#subsubsection.4.7.5 however, only `title' and the default: `small' are proposed for use in this manual.
+
+% NOTE:
+% megakey used to be defined as simply:
+%   \newtcbox{\megakey}[1][small]{colback=black, coltext=white, size=#1, fontupper=\bfseries\uppercase, nobeforeafter,box align=bottom,text height=7pt}
+% while this works, the use of \uppercase gave: "! Missing { inserted" errors in the log. Reimplemented as:
 
 \usepackage{tcolorbox}
 \usepackage[utf8]{inputenc}
 
-\newtcbox{\megakey}[1][small]{colback=black, coltext=white, size=#1, fontupper=\bfseries\uppercase,nobeforeafter,box align=bottom,text height=7pt}
+\newtcbox{\megakeyinner}[1][small]{colback=black, coltext=white, size=#1, fontupper=\bfseries, nobeforeafter,box align=bottom,text height=7pt}
+\newcommand{\megakey}[2][small]{\megakeyinner[#1]{\uppercase{#2}}}

--- a/gettingstarted.tex
+++ b/gettingstarted.tex
@@ -23,7 +23,7 @@ In the case of the function keys, pressing \megakey{Shift} will give you the fun
 
  \vspace*{1cm}
 
-\megakey{\leftarrow} \megakey{\uparrow} \megakey{\rightarrow} \megakey{\downarrow} Cursor Keys
+\megakey{$\leftarrow$} \megakey{$\uparrow$} \megakey{$\rightarrow$} \megakey{$\downarrow$} Cursor Keys
 
 These keys move the cursor around the screen... etc etc.
 

--- a/userguide.tex
+++ b/userguide.tex
@@ -293,7 +293,7 @@ Text to the left \megakey{Run/Stop} and text to the right.
  
 \megakey{Shift} \megakey{CTRL} \megakey{9} \megakey{Clr/Home}  \megakey{ } \megakey{Return} 
 
-\megakey{Inst/Del} \megakey{*} \megakey{Run/Stop} \megakey{\leftarrow} \megakey{\uparrow} \megakey{\rightarrow} \megakey{\downarrow}
+\megakey{Inst/Del} \megakey{*} \megakey{Run/Stop} \megakey{$\leftarrow$} \megakey{$\uparrow$} \megakey{$\rightarrow$} \megakey{$\downarrow$}
 
 \section{Screen Output}
 


### PR DESCRIPTION
Fixed megakey errors by splitting component into a command and tcbox.
Allows uppercase.

* Also changed usage of special characters as $ is required
  at the start and end in those cases. Covered in the component's readme block.

Fixes issue #8 