### PR TITLE
Correct baseline for megakey macro.

### DIFF
--- a/elements/keys.tex
+++ b/elements/keys.tex
@@ -23,5 +23,5 @@
 \usepackage{tcolorbox}
 \usepackage{inputenc}
 
-\newtcbox{\megakeyinner}[1][small]{colback=black, coltext=white, size=#1, fontupper=\bfseries, nobeforeafter,box align=bottom,text height=7pt}
+\newtcbox{\megakeyinner}[1][small]{colback=black, coltext=white, size=#1, fontupper=\bfseries, nobeforeafter,box align=bottom,baseline=3pt,text height=7pt}
 \newcommand{\megakey}[2][small]{\megakeyinner[#1]{\uppercase{#2}}}


### PR DESCRIPTION
This corrects the vertical centre for the
keys with the surrounding text.

#22 