### PR TITLE
 Text revision changes from cheveroninuk's review

### DIFF
--- a/appendix-basic10.tex
+++ b/appendix-basic10.tex
@@ -2,17 +2,15 @@
 
 \section{Format of Commands, Functions and Operators}
 
-In this appendix each of the commands, functions and other callable elements of
-BASIC 10 are described.
-Some of these can take one or more arguments, that is, pieces of input that you
-can (or sometimes must) provide as part of the command or function call.
+This appendix describes each of the commands, functions and other callable elements of BASIC 10.
+Some of these can take one or more arguments, that is, pieces of input that you provide as part of the command or function call.
 Some also require that you use special keywords.
 Here is an example of how commands, functions and operators will be described
 in this appendix:
 
 {\bf KEY <numeric expression>,<string expression> }
 
-In this case, KEY is what we call a {\bf keyword}. That just means a special word that BASIC
+In this case, KEY is what we call a \textbf{keyword}. That just means a special word that BASIC
 understands.  Keywords are always written in CAPITALS, so that you can easily recognise them.
 
 The {\bf <} and {\bf >} signs mean that whatever is between them must be there for the command, function or operator to work.
@@ -99,7 +97,7 @@ Commands are statements that you can use directly from the {\bf READY.} prompt, 
                 the absolute value of the numeric
                 argument {\bf x}. \\
                {\bf x} = numeric argument (integer or real expression).
-\item [Remarks:] the result is of real type.
+\item [Remarks:] The result is of real type.
 \item [Example:] Using {\bf ABS}
 
 \begin{screenoutput}
@@ -122,7 +120,7 @@ Commands are statements that you can use directly from the {\bf READY.} prompt, 
 \item [Token:] \$AF
 \item [Format:] operand {\bf AND} operand
 \item [Usage:]  The boolean {\bf AND} operator performs a bitwise
-                logical AND operation on two 16 bit values.
+                logical AND operation on two 16-bit values.
                 Integer operands are used as they are.
                 Real operands are converted to a signed 16 bit integer.
                 Logical operands are converted to 16 bit integer
@@ -167,7 +165,7 @@ In most cases the {\bf AND} will be used in {\bf IF} statements.
 \item [Format:]
   {\bf APPEND\# lfn, filename [,D drive] [,U unit] }
 \item [Usage:]
-   The append command opens an existing sequential file of type
+   Opens an existing sequential file of type
    SEQ or USR for writing and positions the write pointer
    at the end of the file.
 
@@ -175,17 +173,11 @@ In most cases the {\bf AND} will be used in {\bf IF} statements.
    1 <= lfn <= 127: line terminator is CR \\
    128 <= lfn <= 255: line terminator is CR LF
 
-   {\bf filename} is either a quoted string, e.g. {\bf "data"} or
-   a string expression in parentheses, e.g. {\bf (FN\$)}.
+   \filenamedefinition
 
-   {\bf drive} = drive \# in dual drive disk units. \\
-   The drive \# defaults to 0 and can be omitted on single drive units
-   like the 1581, 1571 or 1541 series.
+   \drivedefinition
 
-   {\bf unit} = device number on the IEC bus.
-   The number is typically in the range 8-11 for disk units.
-   If a variable is used, it must be put in parentheses.
-   The unit \# defaults to 8.
+   \unitdefinition
 
 \item [Remarks:]
    \screentext{APPEND\#} functions similar to the \screentext{DOPEN\#}
@@ -213,7 +205,7 @@ In most cases the {\bf AND} will be used in {\bf IF} statements.
 \begin{description}[leftmargin=3cm,style=nextline]
 \item [Token:] \$C6
 \item [Format:] {\bf ASC}(string)
-\item [Usage:] The {\bf ASC} function takes the first character of
+\item [Usage:] Takes the first character of
                the string argument and returns its numeric code value.
                The name is apparently chosen to be a mnemonic to ASCII,
                but the returned value is in fact the so called PETSCII code.
@@ -239,7 +231,7 @@ In most cases the {\bf AND} will be used in {\bf IF} statements.
 \begin{description}[leftmargin=3cm,style=nextline]
 \item [Token:] \$C1
 \item [Format:] {\bf ATN}(numeric expression)
-\item [Usage:] The {\bf ATN} function returns the arc tangent of the
+\item [Usage:] Returns the arc tangent of the
                argument.
                The result is in the range ($-\pi/2$ to $\pi/2$)
 
@@ -266,7 +258,7 @@ In most cases the {\bf AND} will be used in {\bf IF} statements.
 \item [Token:] \$DC
 \item [Format:]
   {\bf AUTO [step]}
-\item [Usage:] The AUTO command enables faster typing of BASIC programs.
+\item [Usage:] Enables faster typing of BASIC programs.
   After submitting a new program line to the BASIC editor with
   the RETURN key, the AUTO function generates a new BASIC line
   number for the entry of the next line. The new number is
@@ -289,7 +281,7 @@ In most cases the {\bf AND} will be used in {\bf IF} statements.
 \begin{description}[leftmargin=3cm,style=nextline]
 \item [Token:] \$FE \$3B
 \item [Format:] {\bf BACKGROUND} colour
-\item [Usage:] The {\bf BACKGROUND} command sets the background colour
+\item [Usage:] Sets the background colour
                of the screen to the argument, which must be in the
                range 0 to 15. (See colour table).
 \item [Example:] \screentext{BACKGROUND  3} - select background colour cyan.
@@ -331,15 +323,15 @@ In most cases the {\bf AND} will be used in {\bf IF} statements.
 \begin{description}[leftmargin=3cm,style=nextline]
 \item [Token:] \$F6
 \item [Format:] {\bf BACKUP D source TO D target [,U unit]}
-\item [Usage:] The {\bf BACKUP} command can be used on dual drive
+\item [Usage:] Used on dual drive
    disk units only (e.g. 4040, 8050, 8250).
    The backup is done by the disk unit internally.
 
    {\bf source} = drive \# of source disk (0 or 1). \\
    {\bf target} = drive \# of target disk (0 or 1).
 
-\item [Remarks:]  The target disk will be formatted and
-                 a identical copy of the source disk will be written. \\
+\item [Remarks:]  The target disk is formatted and
+                 a identical copy of the source disk is written. \\
                  This command cannot be used for unit to unit copies.
 
 \item [Example:] \screentext{BACKUP D0 TO D1} - copy disk in drive 0 to
@@ -357,8 +349,8 @@ In most cases the {\bf AND} will be used in {\bf IF} statements.
 \begin{description}[leftmargin=3cm,style=nextline]
 \item [Token:] \$FE \$02
 \item [Format:] {\bf BANK} banknumber
-\item [Usage:] The {\bf BANK} command selects the memory configuration
-               for BASIC commands, that use 16 bit addresses.
+\item [Usage:] Selects the memory configuration
+               for BASIC commands, that use 16-bit addresses.
                These are LOAD, SAVE, PEEK, POKE, WAIT and SYS.
                See system memory map for details.
 \item [Remarks:] A value > 127 selects memory mapped I/O.
@@ -435,11 +427,10 @@ In most cases the {\bf AND} will be used in {\bf IF} statements.
 \item [Format:] {\bf BLOAD filename [,B bank]
                 [,P address]  [,D drive] [,U unit] }
 \item [Usage:]
-   The {\bf BLOAD} ("Binary LOAD") loads a file of type
+   "Binary LOAD" loads a file of type
    PRG into RAM at address P and bank B.
 
-   {\bf filename} is either a quoted string, e.g. {\bf "data"} or
-   a string expression in parentheses, e.g. {\bf (FN\$)}.
+   \filenamedefinition
 
    {\bf bank} specifies the RAM bank to be used.
    If not specified the current bank, as set with the last
@@ -448,14 +439,9 @@ In most cases the {\bf AND} will be used in {\bf IF} statements.
    {\bf address} can be used to overrule the load address,
    that is stored in the first two bytes of the PRG file.
 
-   {\bf drive} = drive \# in dual drive disk units. \\
-   The drive \# defaults to 0 and can be omitted on single drive units
-   like the 1581, 1571 or 1541 series.
+   \drivedefinition
 
-   {\bf unit} = device number on the IEC bus.
-   The number is typically in the range 8-11 for disk units.
-   If a variable is used, it must be put in parentheses.
-   The unit \# defaults to 8.
+   \unitdefinition
 
 \item [Remarks:]
    If the loading process tries to load beyond the address \$FFFF,
@@ -483,11 +469,11 @@ In most cases the {\bf AND} will be used in {\bf IF} statements.
                 {\bf BOOT SYS} \\
                 {\bf BOOT} 
 \item [Usage:]
-   The {\bf BOOT filename} loads a file of type
+   {\bf BOOT filename} loads a file of type
    PRG into RAM at address P and bank B and starts executing
    the code at the load address.
 
-   The {\bf BOOT SYS} loads the boot sector from sector 0,
+   {\bf BOOT SYS} loads the boot sector from sector 0,
    track 1 and unit 8 to address \$0400 on bank 0 and
    performs a JSR \$0400 afterwards (Jump To Subroutine).
 
@@ -495,8 +481,7 @@ In most cases the {\bf AND} will be used in {\bf IF} statements.
    and execute a file named AUTOBOOT.C65 from the default unit 8.
    It's short for {\bf RUN "AUTOBOOT.C65"}.
 
-   {\bf filename} is either a quoted string, e.g. {\bf "data"} or
-   a string expression in parentheses, e.g. {\bf (FN\$)}.
+   \filenamedefinition
 
    {\bf bank} specifies the RAM bank to be used.
    If not specified the current bank, as set with the last
@@ -505,14 +490,9 @@ In most cases the {\bf AND} will be used in {\bf IF} statements.
    {\bf address} can be used to overrule the load address,
    that is stored in the first two bytes of the PRG file.
 
-   {\bf drive} = drive \# in dual drive disk units. \\
-   The drive \# defaults to 0 and can be omitted on single drive units
-   like the 1581, 1571 or 1541 series.
+   \drivedefinition
 
-   {\bf unit} = device number on the IEC bus.
-   The number is typically in the range 8-11 for disk units.
-   If a variable is used, it must be put in parentheses.
-   The unit \# defaults to 8.
+   \unitdefinition
 
 \item [Remarks:]
    {\bf BOOT SYS} copies the contents of one physical sector
@@ -536,7 +516,7 @@ In most cases the {\bf AND} will be used in {\bf IF} statements.
 \begin{description}[leftmargin=3cm,style=nextline]
 \item [Token:] \$FE \$3C
 \item [Format:] {\bf BORDER} colour
-\item [Usage:] The {\bf BORDER} command sets the border colour
+\item [Usage:] Sets the border colour
                of the screen to the argument, which must be in the
                range 0 to 15. (See colour table).
 \item [Example:] \screentext{BORDER  4} - select background colour magenta.
@@ -579,7 +559,7 @@ In most cases the {\bf AND} will be used in {\bf IF} statements.
 \begin{description}[leftmargin=3cm,style=nextline]
 \item [Token:] \$E1
 \item [Format:] {\bf BOX X0,Y0, X1,Y1, X2,Y2, X3,Y3, SOLID}
-\item [Usage:] {\bf BOX} draws a polygon by connecting the
+\item [Usage:] Draws a polygon by connecting the
                coordinate pairs 0 -> 1 -> 2 -> 3 -> 0.
                The polygon is drawn using the current drawing context
                set with SCREEN, PALETTE and PEN.
@@ -618,11 +598,10 @@ In most cases the {\bf AND} will be used in {\bf IF} statements.
 \item [Format:] {\bf BSAVE filename ,P start TO end
                 [,B bank] [,D drive] [,U unit] }
 \item [Usage:]
-   The {\bf BSAVE} ("Binary SAVE") saves a memory range to
+   "Binary SAVE" saves a memory range to
    a file of type PRG.
 
-   {\bf filename} is either a quoted string, e.g. {\bf "data"} or
-   a string expression in parentheses, e.g. {\bf (FN\$)}
+   \filenamedefinition
    If the first character of the filename is an at-sign '@' it
    is interpreted as a "save and replace" operation. It is dangerous
    to use this replace option on drives 1541 and 1571, because they
@@ -639,14 +618,9 @@ In most cases the {\bf AND} will be used in {\bf IF} statements.
    {\bf end} Is the address, where the saving stops.
    {\bf end-1} is the last address to be used for saving.
 
-   {\bf drive} = drive \# in dual drive disk units. \\
-   The drive \# defaults to 0 and can be omitted on single drive units
-   like the 1581, 1571 or 1541 series.
+   \drivedefinition
 
-   {\bf unit} = device number on the IEC bus.
-   The number is typically in the range 8-11 for disk units.
-   If a variable is used, it must be put in parentheses.
-   The unit \# defaults to 8.
+   \unitdefinition
 
 \item [Remarks:]
    The length of the file is {\bf end - start + 2}.
@@ -670,19 +644,19 @@ In most cases the {\bf AND} will be used in {\bf IF} statements.
 \begin{description}[leftmargin=3cm,style=nextline]
 \item [Token:] \$CE \$03
 \item [Format:] {\bf b = BUMP(type)}
-\item [Usage:]  The {\bf BUMP} function can be used to detect
+\item [Usage:] Used to detect
                sprite-sprite (type=1) or sprite-data (type=2) collisions.
-               the return value {\bf b} is a 8 bit mask with
-               1 bit per sprite. The bit position corresponds with the
+               the return value {\bf b} is a 8-bit mask with
+               one bit per sprite. The bit position corresponds with the
                sprite number.
-               Eachs bit set in the return value indicates, that the
-               sprite for this postion was involved in a collision
+               Each bit set in the return value indicates, that the
+               sprite for this position was involved in a collision
                since the last call of {\bf BUMP}.
                Calling {\bf BUMP} resets the collision mask, so you
                get always a summary of collisions encountered since
                the last call of {\bf BUMP}.
 
-\item [Remarks:] It is possible to detect multiple collisions,
+\item [Remarks:] It's possible to detect multiple collisions,
                but you need to evaluate sprite coordinates then
                to detect which sprite collided with which one.
 
@@ -725,11 +699,10 @@ In most cases the {\bf AND} will be used in {\bf IF} statements.
 \item [Format:] {\bf BVERIFY filename [,P address]
                 [,B bank] [,D drive] [,U unit] }
 \item [Usage:]
-   The {\bf BVERIFY} ("Binary VERIFY") compares a memory range to
+   "Binary VERIFY" compares a memory range to
    a file of type PRG.
 
-   {\bf filename} is either a quoted string, e.g. {\bf "data"} or
-   a string expression in parentheses, e.g. {\bf (FN\$)}
+   \filenamedefinition
 
    {\bf bank} specifies the RAM bank to be used.
    If not specified the current bank, as set with the last
@@ -739,14 +712,9 @@ In most cases the {\bf AND} will be used in {\bf IF} statements.
    If the parameter P is omitted, it is the load address,
    that is stored in the first two bytes of the PRG file.
 
-   {\bf drive} = drive \# in dual drive disk units. \\
-   The drive \# defaults to 0 and can be omitted on single drive units
-   like the 1581, 1571 or 1541 series.
+   \drivedefinition
 
-   {\bf unit} = device number on the IEC bus.
-   The number is typically in the range 8-11 for disk units.
-   If a variable is used, it must be put in parentheses.
-   The unit \# defaults to 8.
+   \unitdefinition
 
 \item [Remarks:]
    {\bf BVERIFY} can only test for equality. It gives no information
@@ -775,31 +743,26 @@ In most cases the {\bf AND} will be used in {\bf IF} statements.
 \item [Token:] \$FE \$0C
 \item [Format:] {\bf CATALOG [filepattern] [,R] [,D drive] [,U unit] }
 \item [Usage:]
-   The {\bf CATALOG} command prints a listing
+   Prints a listing
    of the specified disk.
 
    The {\bf R} (Recoverable) parameter includes files in the
    directory, which are flagged as deleted but are still
    recoverable.
 
-   {\bf filepattern} is either a quoted string, e.g. {\bf "da*"} or
+   {\bf filepattern} is either a quoted string, for example: {\bf "da*"} or
    a string expression in parentheses, e.g. {\bf (DI\$)}
 
-   {\bf drive} = drive \# in dual drive disk units. \\
-   The drive \# defaults to 0 and can be omitted on single drive units
-   like the 1581, 1571 or 1541 series.
+   \drivedefinition
 
-   {\bf unit} = device number on the IEC bus.
-   The number is typically in the range 8-11 for disk units.
-   If a variable is used, it must be put in parentheses.
-   The unit \# defaults to 8.
+   \unitdefinition
 
 \item [Remarks:]
    The command {\bf CATALOG} is a synonym for {\bf DIRECTORY}
    or {\bf DIR} and produces the same listing.
    The {\bf filepattern} can be used to restrict the listing.
-   The wildcard characters '*' and '?' may be used.
-   Adding a ",T=" to the pattern string, with T specifying
+   The wildcard characters \screentext{*} and \screentext{?} may be used.
+   Adding a \screentext{,T=} to the pattern string, with T specifying
    a filetype P,S,U or R (for PRG,SEQ,USR,REL) restricts the
    output to that filetype.
 
@@ -828,16 +791,16 @@ DIRECTORY "*,T=S"
 \begin{description}[leftmargin=3cm,style=nextline]
 \item [Token:] \$FE \$0C
 \item [Format:] {\bf CHANGE "find" TO "replace" [,from-to]}
-\item [Usage:]  {\bf CHANGE} is an editor command and can be used
+\item [Usage:]  Used
                 in direct mode only. It searches the line range
                 if specified or the whole BASIC program else.
-                At each occurence of the "find string" the line is
+                At each occurrence of the "find string" the line is
                 listed and the user prompted for an action: \\
                 'Y' <RETURN> do the change and find next string \\
                 'N' <RETURN> do {\bf not} change and find next string \\
                 '*' <RETURN> change this and all following matches \\
                     <RETURN> exit command, don't change.
-\item [Remarks:] Instead of the quote (") each other character may be used
+\item [Remarks:] Instead of the quote (\screentext{"}) each other character may be used
                  as delimiter for the findstring and replacestring.
                  Using the quote as delimiter finds text strings, that are
                  not tokenized and therefore not part of a keyword. \\
@@ -865,7 +828,7 @@ CHANGE &IN& TO &OUT&
 \item [Token:] \$E0
 \item [Format:] {\bf CHAR column, row, height, width, direction, string
                 [, address of character set]}
-\item [Usage:]  {\bf CHAR} is used to display text on a graphic screen.
+\item [Usage:]  Displays text on a graphic screen.
                 It can be used for all resolutions.
 
                 {\bf column} is the start position of the output
@@ -880,11 +843,11 @@ CHANGE &IN& TO &OUT&
 
                 {\bf height} is a factor applied to the vertical
                 size of the characters. 1 is normal size (8 pixels)
-                2 is double size (16 pixels), etc.
+                2 is double size (16 pixels), and so on.
 
-                {\bf widht} is a factor applied to the horizontal
+                {\bf width} is a factor applied to the horizontal
                 size of the characters. 1 is normal size (8 pixels)
-                2 is double size (16 pixels), etc.
+                2 is double size (16 pixels), and so on.
 
                 {\bf direction} controls the printing direction: \\
                 1: up     \\
@@ -902,7 +865,7 @@ CHANGE &IN& TO &OUT&
 
 \item [Remarks:]
                 Control characters,
-                e.g. cursor movement codes, will be ignored
+                for example: cursor movement codes, will be ignored
                 (neither printed nor interpreted).
 
 
@@ -922,7 +885,7 @@ will printh the text "MEGA 65" on the centre of a 640 x 400 graphic screen.
 \begin{description}[leftmargin=3cm,style=nextline]
 \item [Token:] \$C1
 \item [Format:] {\bf CHR\$(numeric expression)}
-\item [Usage:] The {\bf CHR\$} function returns a string of length 1
+\item [Usage:] Returns a string of length one character
                using the argument to insert the character having this
                value as PETSCII code.
 
@@ -948,7 +911,7 @@ will printh the text "MEGA 65" on the centre of a 640 x 400 graphic screen.
 \begin{description}[leftmargin=3cm,style=nextline]
 \item [Token:] \$E2
 \item [Format:] {\bf CIRCLE xcentre, ycentre, radius, [,solid]}
-\item [Usage:] The {\bf CIRCLE} command is a special case of
+\item [Usage:] A special case of
                the {\bf ELLIPSE} command using the same value for
                horizontal and vertical radius.
 
@@ -961,8 +924,8 @@ will printh the text "MEGA 65" on the centre of a 640 x 400 graphic screen.
                {\bf solid} will fill the circle if not zero.
 
 \item [Remarks:] The {\bf CIRCLE} command is used to draw circles on
-               screens with an aspect ratio 1:1 (e.g. 320 x200
-               or 640 x 400). On other resolutions (e.g. 640 x 200)
+               screens with an aspect ratio 1:1 (for example: 320 x 200
+               or 640 x 400). On other resolutions (like: 640 x 200)
                the shape will degrade to an ellipse.
 
 \item [Example:] Using {\bf CIRCLE}
@@ -982,7 +945,7 @@ will printh the text "MEGA 65" on the centre of a 640 x 400 graphic screen.
 \begin{description}[leftmargin=3cm,style=nextline]
 \item [Token:] \$A0
 \item [Format:] {\bf CLOSE channel}
-\item [Usage:] The {\bf CLOSE} command closes an input or output
+\item [Usage:] Closes an input or output
                channel, that was established before by an {\bf OPEN}
                command.
 
@@ -1013,7 +976,7 @@ will printh the text "MEGA 65" on the centre of a 640 x 400 graphic screen.
 \begin{description}[leftmargin=3cm,style=nextline]
 \item [Token:] \$9C
 \item [Format:] {\bf CLR}
-\item [Usage:] The {\bf CLR} command resets all pointers, that
+\item [Usage:] Resets all pointers, that
                are used for management of BASIC variables, arrays
                and strings. The runtime stack pointers are reset
                and the table of open channels is reset.
@@ -1044,7 +1007,7 @@ READY.
 \begin{description}[leftmargin=3cm,style=nextline]
 \item [Token:] \$9D
 \item [Format:] {\bf CMD channel [,string]}
-\item [Usage:] The {\bf CMD} command redirects the standard output
+\item [Usage:] Redirects the standard output
                from screen to the channel. This enables to
                print listings and directories or other screen outputs.
                It is also possible to redirect this output to a disk file
@@ -1052,7 +1015,7 @@ READY.
 
                {\bf channel} must be opened by the {\bf OPEN} command.
 
-               The optional {\bf string} will be sent to the channel
+               The optional {\bf string} is sent to the channel
                before the redirection begins and can be used,
                for example, for printer setup escape sequences.
 
@@ -1081,22 +1044,17 @@ CLOSE 4
 \item [Token:] \$F3
 \item [Format:] {\bf COLLECT [,D drive] [,U unit] }
 \item [Usage:]
-   The {\bf COLLECT} command rebuilds the {\bf BAM}
+   Rebuilds the {\bf BAM}
    (Block Availabilty Map) deleting splat files and marking
    unused blocks as free.
 
-   {\bf drive} = drive \# in dual drive disk units. \\
-   The drive \# defaults to 0 and can be omitted on single drive units
-   like the 1581, 1571 or 1541 series.
+   \drivedefinition
 
-   {\bf unit} = device number on the IEC bus.
-   The number is typically in the range 8-11 for disk units.
-   If a variable is used, it must be put in parentheses.
-   The unit \# defaults to 8.
+   \unitdefinition
 
 \item [Remarks:]
    While this command is useful for cleaning the disk from
-   splat files (e.g. write files, that weren't properly closed)
+   splat files (for example: write files, that weren't properly closed)
    it is dangerous for disks with boot blocks or random access files.
    These blocks are not associated with standard disk files
    and will therefore be marked as free too and may be overwritten
@@ -1120,14 +1078,14 @@ CLOSE 4
 \begin{description}[leftmargin=3cm,style=nextline]
 \item [Token:] \$FE \$17
 \item [Format:] {\bf COLLISION type [,linenumber]}
-\item [Usage:]  The {\bf COLLISION} statement enables or disables
+\item [Usage:]  Enables or disables
                 an user programmed interrupt handler.
                 A call without linenumber disables the handler,
                 while a call with linenumber enables it.
                 After the execution of {\bf COLLISION} with
                 linenumber a sprite collision of the same type,
-                as specified in the {\bf COLLISION} call, will
-                interrupt the BASIC program and perform a {\bf GOSUB}
+                as specified in the {\bf COLLISION} call,
+                interrupts the BASIC program and perform a {\bf GOSUB}
                 to {\bf linenumber} which is expected to contain
                 the user code for handling sprite collisions.
                 This handler must give control back with a {\bf RETURN}.
@@ -1173,7 +1131,7 @@ CLOSE 4
 \begin{description}[leftmargin=3cm,style=nextline]
 \item [Token:] \$E7
 \item [Format:] {\bf COLOR <ON|OFF>}
-\item [Usage:] The {\bf COLOR} command enables or disables
+\item [Usage:] Enables or disables
                handling of the character attributes on the screen.
                If {\bf COLOR} is {\bf ON}, the screen routines
                take care for both character RAM and attribute RAM.
@@ -1205,11 +1163,11 @@ CLOSE 4
    contains the contents of both files, while {\bf appendfile}
    remains unchanged.
 
-   {\bf appendfile} is either a quoted string, e.g. {\bf "data"} or
-   a string expression in parentheses, e.g. {\bf (FN\$)}
+   {\bf appendfile} is either a quoted string, for example: {\bf "data"} or
+   a string expression in parentheses, for example: {\bf (FN\$)}
 
-   {\bf targetfile} is either a quoted string, e.g. {\bf "safe"} or
-   a string expression in parentheses, e.g. {\bf (FS\$)}
+   {\bf targetfile} is either a quoted string, for example: {\bf "safe"} or
+   a string expression in parentheses, for example: {\bf (FS\$)}
 
    If the disk unit has dual drives, it is possible to apply
    the {\bf CONCAT} command to files, which are stored on different
@@ -1217,14 +1175,9 @@ CLOSE 4
    for both files in the command. This is necessary too, if both
    files are stored on drive\#1.
 
-   {\bf drive} = drive \# in dual drive disk units. \\
-   The drive \# defaults to 0 and can be omitted on single drive units
-   like the 1581, 1571 or 1541 series.
+   \drivedefinition
 
-   {\bf unit} = device number on the IEC bus.
-   The number is typically in the range 8-11 for disk units.
-   If a variable is used, it must be put in parentheses.
-   The unit \# defaults to 8.
+   \unitdefinition
 
 \item [Remarks:]
    The {\bf CONCAT} commands is executed in the DOS of the disk drive.
@@ -1247,7 +1200,7 @@ CLOSE 4
 \begin{description}[leftmargin=3cm,style=nextline]
 \item [Token:] \$9A
 \item [Format:] {\bf CONT}
-\item [Usage:] The {\bf CONT} (continue) command is used to resume
+\item [Usage:] Used to resume
                program execution after a break or stop caused by
                an {\bf END} or {\bf STOP} statement or by pressing
                the {\bf STOP KEY}.
@@ -1283,7 +1236,7 @@ CONT
 \item [Format:] {\bf COPY source [,D drives] TO
                 target [,D drivet] [,U unit] }
 \item [Usage:]
-   The {\bf COPY} copies the contents of
+   Copies the contents of
    {\bf source} to the {\bf target}.
    It is used to copy either single files or, by using
    wildcard characters, multiple files.
@@ -1300,14 +1253,9 @@ CONT
    for source and target in the command. This is necessary too, if both
    files are stored on drive\#1.
 
-   {\bf drive} = drive \# in dual drive disk units. \\
-   The drive \# defaults to 0 and can be omitted on single drive units
-   like the 1581, 1571 or 1541 series.
+   \drivedefinition
 
-   {\bf unit} = device number on the IEC bus.
-   The number is typically in the range 8-11 for disk units.
-   If a variable is used, it must be put in parentheses.
-   The unit \# defaults to 8.
+   \unitdefinition
 
 \item [Remarks:]
    The {\bf COPY} commands is executed in the DOS of the disk drive.
@@ -1360,7 +1308,7 @@ CONT
 \begin{description}[leftmargin=3cm,style=nextline]
 \item [Token:] \$83
 \item [Format:] {\bf DATA} [list of constants]
-\item [Usage:] The {\bf DATA} statement is used to define constants
+\item [Usage:] Used to define constants
                which can be read by {\bf READ} statements somewhere
                in the program. All type of constants (integer, real,
                strings) are allowed, but no expressions.
@@ -1410,17 +1358,12 @@ CONT
 \item [Token:] \$FE \$15
 \item [Format:] {\bf DCLEAR [,D drive] [,U unit] }
 \item [Usage:]
-   The {\bf DCLEAR} command sends an initialize command to
+   Sends an initialise command to
    the specified unit and drive.
 
-   {\bf drive} = drive \# in dual drive disk units. \\
-   The drive \# defaults to 0 and can be omitted on single drive units
-   like the 1581, 1571 or 1541 series.
+   \drivedefinition
 
-   {\bf unit} = device number on the IEC bus.
-   The number is typically in the range 8-11 for disk units.
-   If a variable is used, it must be put in parentheses.
-   The unit \# defaults to 8.
+   \unitdefinition
 
 \item [Remarks:]
    The DOS inside the disk unit will close all open files,
@@ -1447,15 +1390,12 @@ CONT
 \item [Token:] \$FE \$0F
 \item [Format:] {\bf DCLOSE [\#channel] [,U unit] }
 \item [Usage:]
-   The {\bf DCLOSE} command closes a single file or
+   Closes a single file or
    all files for the specified unit.
 
    {\bf channel} = channel \# assigned with the {\bf DOPEN} statement.
 
-   {\bf unit} = device number on the IEC bus.
-   The number is typically in the range 8-11 for disk units.
-   If a variable is used, it must be put in parentheses.
-   The unit \# defaults to 8.
+   \unitdefinition
 
    The {\bf DCLOSE} command is used either with a channel argument
    or a unit number, but never both.
@@ -1481,7 +1421,7 @@ CONT
 \begin{description}[leftmargin=3cm,style=nextline]
 \item [Token:] \$D1
 \item [Format:] {\bf DEC(string expression)}
-\item [Usage:] The {\bf DEC} function returns the decimal value
+\item [Usage:] Returns the decimal value
                of the argument, that is written as a hex string.
                The argument range is "0000" to "FFFF" or
                0 to 65535 respectively.
@@ -1508,7 +1448,7 @@ CONT
 \begin{description}[leftmargin=3cm,style=nextline]
 \item [Token:] \$96
 \item [Format:] {\bf DEF FN name(real variable)}
-\item [Usage:] The {\bf DEF} function defines a single statement
+\item [Usage:] Defines a single statement
                user function with one argument of real type
                returning a real value.
                The definition must be executed before the function
@@ -1549,7 +1489,7 @@ RUN
 \item [Token:] \$F7
 \item [Format:] {\bf DELETE [line range]} \\
                 {\bf DELETE filename [,D drive] [,U unit] [,R]}
-\item [Usage:] The {\bf DELETE} command is used either to delete
+\item [Usage:] Used either to delete
                a range of lines from the BASIC program or
                to delete a disk file.
 
@@ -1560,17 +1500,12 @@ RUN
                The second number in the range specifier defaults
                to the last BASIC line.
 
-   {\bf filename} is either a quoted string, e.g. {\bf "safe"} or
-   a string expression in parentheses, e.g. {\bf (FS\$)}
+   {\bf filename} is either a quoted string, for example: {\bf "safe"} or
+   a string expression in parentheses, for example: {\bf (FS\$)}
 
-   {\bf drive} = drive \# in dual drive disk units. \\
-   The drive \# defaults to 0 and can be omitted on single drive units
-   like the 1581, 1571 or 1541 series.
+   \drivedefinition
 
-   {\bf unit} = device number on the IEC bus.
-   The number is typically in the range 8-11 for disk units.
-   If a variable is used, it must be put in parentheses.
-   The unit \# defaults to 8.
+   \unitdefinition
 
    {\bf R} = Recover a previously deleted file.
    This will only work, if there were no write operations
@@ -1600,7 +1535,7 @@ RUN
 \begin{description}[leftmargin=3cm,style=nextline]
 \item [Token:] \$86
 \item [Format:] {\bf DIM name(limits) [,name(limits)]...}
-\item [Usage:] The {\bf DIM} statement declares the shape,
+\item [Usage:] Declares the shape,
                the bounds and the type of a BASIC array.
                As a declaration statement it must be executed
                only once and before any usage of the declared arrays.
@@ -1615,8 +1550,8 @@ RUN
                variables and array variables. The left parenthesis
                after the name identifies array names.
 
-\item [Remarks:] Integer arrays consume 2 bytes per element,
-                 real arrays 5 bytes and string arrays 3 bytes
+\item [Remarks:] Integer arrays consume two bytes per element,
+                 real arrays five bytes and string arrays three bytes
                  for the string descriptor plus
                  the length of the string. \\
                  If an array identifier is used without previous
@@ -1644,7 +1579,7 @@ RUN
 \item [Token:] \$EE
 \item [Format:] {\bf DIRECTORY [filepattern] [,R] [,D drive] [,U unit] }
 \item [Usage:]
-   The {\bf DIRECTORY} command prints a listing
+   Prints a listing
    of the specified disk and may be abbreviated to {\bf DIR}.
 
    The {\bf R} (Recoverable) parameter includes files in the
@@ -1654,14 +1589,9 @@ RUN
    {\bf filepattern} is either a quoted string, e.g. {\bf "da*"} or
    a string expression in parentheses, e.g. {\bf (DI\$)}
 
-   {\bf drive} = drive \# in dual drive disk units. \\
-   The drive \# defaults to 0 and can be omitted on single drive units
-   like the 1581, 1571 or 1541 series.
+	 \drivedefinition
 
-   {\bf unit} = device number on the IEC bus.
-   The number is typically in the range 8-11 for disk units.
-   If a variable is used, it must be put in parentheses.
-   The unit \# defaults to 8.
+	 \unitdefinition
 
 \item [Remarks:]
    The command {\bf DIRECTORY} is a synonym for {\bf CATALOG}
@@ -1698,13 +1628,10 @@ DIR "*,T=S"
 \item [Token:] \$FE \$40
 \item [Format:] {\bf DISK command [,U unit] }
 \item [Usage:]
-   The {\bf DISK} command sends a command string to the
+   Sends a command string to the
    specified disk unit.
 
-   {\bf unit} = device number on the IEC bus.
-   The number is typically in the range 8-11 for disk units.
-   If a variable is used, it must be put in parentheses.
-   The unit \# defaults to 8.
+   \unitdefinition
 
    {\bf command} is a string expression.
 
@@ -1730,23 +1657,17 @@ DIR "*,T=S"
 \item [Token:] \$F0
 \item [Format:] {\bf DLOAD filename [,D drive] [,U unit] }
 \item [Usage:]
-   The {\bf DLOAD} ("Disk LOAD") loads a file of type
+   "Disk LOAD" loads a file of type
    PRG into memory reserved for BASIC program source.
 
-   {\bf filename} is either a quoted string, e.g. {\bf "data"} or
-   a string expression in parentheses, e.g. {\bf (FN\$)}.
+   \filenamedefinition
 
-   {\bf drive} = drive \# in dual drive disk units. \\
-   The drive \# defaults to 0 and can be omitted on single drive units
-   like the 1581, 1571 or 1541 series.
+   \drivedefinition
 
-   {\bf unit} = device number on the IEC bus.
-   The number is typically in the range 8-11 for disk units.
-   If a variable is used, it must be put in parentheses.
-   The unit \# defaults to 8.
+   \unitdefinition
 
 \item [Remarks:]
-   The load address, which is stored in the first two bytes
+   The load address, stored in the first two bytes
    of the file is ignored. The program is loaded into
    the BASIC memory. This enables loading of BASIC programs,
    that were saved on other computers with different memory
@@ -1777,7 +1698,7 @@ DIR "*,T=S"
 \item [Token:] \$FE \$23
 \item [Format:] {\bf DMA command [,length, source, target, sub]}
 \item [Usage:]
-   The {\bf DMA} ("Direct Memory Access) command is the fastest method
+   The {\bf DMA} ("Direct Memory Access") command is the fastest method
    to manipulate memory areas using the DMA controller.
 
    {\bf command} 0 = copy, 1 = mix, 2 = swap, 3 = fill
@@ -1811,7 +1732,7 @@ DMA 0, 2000, 2048,0, 32768,1 :REM COPY SCREEN TO $1800
 \item [Token:] \$FE \$35
 \item [Format:] {\bf DMODE jam,complement,inverse,stencil,style,thick}
 \item [Usage:]
-   The {\bf DMODE} ("Display MODE") sets several parameter
+   "Display MODE" sets several parameter
    of the graphical context for drawing commands.
 
 \ttfamily
@@ -1880,7 +1801,7 @@ DMA 0, 2000, 2048,0, 32768,1 :REM COPY SCREEN TO $1800
 \item [Format:]
   {\bf DOPEN\# lfn, filename [,L[reclen]] [,W] [,D drive] [,U unit] }
 \item [Usage:]
-   The {\bf DOPEN} command opens a file for reading, writing or
+   Opens a file for reading, writing or
    modifying.
 
    {\bf lfn} = {\bf l}ogical {\bf f}ile {\bf n}umber \\
@@ -1894,17 +1815,11 @@ DMA 0, 2000, 2048,0, 32768,1 :REM COPY SCREEN TO $1800
 
    {\bf W} opens a file for write access. The file must not exist.
 
-   {\bf filename} is either a quoted string, e.g. {\bf "data"} or
-   a string expression in parentheses, e.g. {\bf (FN\$)}.
+   \filenamedefinition
 
-   {\bf drive} = drive \# in dual drive disk units. \\
-   The drive \# defaults to 0 and can be omitted on single drive units
-   like the 1581, 1571 or 1541 series.
+   \drivedefinition
 
-   {\bf unit} = device number on the IEC bus.
-   The number is typically in the range 8-11 for disk units.
-   If a variable is used, it must be put in parentheses.
-   The unit \# defaults to 8.
+   \unitdefinition
 
 \item [Remarks:]
    \screentext{DOPEN\#} may be used to open all file types.
@@ -1940,7 +1855,7 @@ DMA 0, 2000, 2048,0, 32768,1 :REM COPY SCREEN TO $1800
 \item [Token:] \$FE \$36
 \item [Format:] {\bf DPAT type [,number, pattern, ...]}
 \item [Usage:]
-   The {\bf DPAT} ("Drawing PATtern") command sets pattern
+   "Drawing PATtern" sets pattern
    of the graphical context for drawing commands.
 
 \ttfamily
@@ -1963,25 +1878,19 @@ DMA 0, 2000, 2048,0, 32768,1 :REM COPY SCREEN TO $1800
 \item [Token:] \$EF
 \item [Format:] {\bf DSAVE filename [,D drive] [,U unit] }
 \item [Usage:]
-   The {\bf DSAVE} ("Disk SAVE") saves a BASIC program to
+   "Disk SAVE" saves a BASIC program to
    a file of type PRG.
 
-   {\bf filename} is either a quoted string, e.g. {\bf "data"} or
-   a string expression in parentheses, e.g. {\bf (FN\$)}
+   \filenamedefinition
    The maximum length of the filename is 16 characters.
    If the first character of the filename is an at-sign '@' it
    is interpreted as a "save and replace" operation. It is dangerous
    to use this replace option on drives 1541 and 1571, because they
    contain the notorious "save and replace bug" in their DOS.
 
-   {\bf drive} = drive \# in dual drive disk units. \\
-   The drive \# defaults to 0 and can be omitted on single drive units
-   like the 1581, 1571 or 1541 series.
+   \drivedefinition
 
-   {\bf unit} = device number on the IEC bus.
-   The number is typically in the range 8-11 for disk units.
-   If a variable is used, it must be put in parentheses.
-   The unit \# defaults to 8.
+   \unitdefinition
 
 \item [Remarks:]
    The {\bf DVERIFY} can be used after {\bf DSAVE} to check,
@@ -2006,20 +1915,14 @@ DMA 0, 2000, 2048,0, 32768,1 :REM COPY SCREEN TO $1800
 \item [Token:] \$FE \$14
 \item [Format:] {\bf DVERIFY filename [,D drive] [,U unit] }
 \item [Usage:]
-   The {\bf DVERIFY} ("Disk VERIFY") compares a BASIC program
+   "Disk VERIFY" compares a BASIC program
    in memory with a disk file of type PRG.
 
-   {\bf filename} is either a quoted string, e.g. {\bf "data"} or
-   a string expression in parentheses, e.g. {\bf (FN\$)}
+   \filenamedefinition
 
-   {\bf drive} = drive \# in dual drive disk units. \\
-   The drive \# defaults to 0 and can be omitted on single drive units
-   like the 1581, 1571 or 1541 series.
+   \drivedefinition
 
-   {\bf unit} = device number on the IEC bus.
-   The number is typically in the range 8-11 for disk units.
-   If a variable is used, it must be put in parentheses.
-   The unit \# defaults to 8.
+   \unitdefinition
 
 \item [Remarks:]
    {\bf DVERIFY} can only test for equality. It gives no information
@@ -2045,7 +1948,7 @@ DMA 0, 2000, 2048,0, 32768,1 :REM COPY SCREEN TO $1800
 \item [Format:] {\bf EL} is a reserved system variable
 \item [Usage:]  {\bf EL} has the value of the line, where
                the latest BASIC error
-               occured or the value -1 if there was no error.
+               occurred or the value -1 if there was no error.
 
 This variable is typically used in a TRAP routine,
 where the error line is taken from {\bf EL}.
@@ -2070,7 +1973,7 @@ where the error line is taken from {\bf EL}.
 \item [Token:] \$FE \$30
 \item [Format:] {\bf ELLIPSE xcentre, ycentre,
                 xradius, yradius, [,solid]}
-\item [Usage:] As the name says, it drwas an ellipse.
+\item [Usage:] As the name says, it draws an ellipse.
 
                {\bf xcentre} x coordinate of centre in pixels.
 
@@ -2149,7 +2052,7 @@ where the error line is taken from {\bf EL}.
 \begin{description}[leftmargin=3cm,style=nextline]
 \item [Token:] \$80
 \item [Format:] {\bf END}
-\item [Usage:] The {\bf END} statement ends the execution
+\item [Usage:] Ends the execution
                of the BASIC program. The {\bf READY.} prompt
                appears and the computer goes into direct mode
                waiting for keyboard input.
@@ -2180,7 +2083,7 @@ where the error line is taken from {\bf EL}.
 \item [Token:] \$FE \$0A
 \item [Format:] {\bf ENVELOPE n, [attack,decay,sustain,release,
                 waveform,pw]}
-\item [Usage:] The {\bf ENVELOPE} command is used to define
+\item [Usage:] Used to define
                the parameters for the synthesis of a musical
                instrument.
 
@@ -2241,20 +2144,14 @@ where the error line is taken from {\bf EL}.
 \begin{description}[leftmargin=3cm,style=nextline]
 \item [Token:] \$FE \$2A
 \item [Format:] {\bf ERASE filename [,D drive] [,U unit] [,R]}
-\item [Usage:] The {\bf ERASE} command is used
+\item [Usage:] Used
                to erase a disk file.
 
-   {\bf filename} is either a quoted string, e.g. {\bf "safe"} or
-   a string expression in parentheses, e.g. {\bf (FS\$)}
+   \filenamedefinition
 
-   {\bf drive} = drive \# in dual drive disk units. \\
-   The drive \# defaults to 0 and can be omitted on single drive units
-   like the 1581, 1571 or 1541 series.
+   \drivedefinition
 
-   {\bf unit} = device number on the IEC bus.
-   The number is typically in the range 8-11 for disk units.
-   If a variable is used, it must be put in parentheses.
-   The unit \# defaults to 8.
+   \unitdefinition
 
    {\bf R} = Recover a previously erased file.
    This will only work, if there were no write operations
@@ -2280,7 +2177,7 @@ where the error line is taken from {\bf EL}.
 \begin{description}[leftmargin=3cm,style=nextline]
 \item [Format:] {\bf ER} is a reserved system variable
 \item [Usage:]  {\bf ER} has the value of the latest BASIC error
-               occured or the value -1 if there was no error.
+               occurred or the value -1 if there was no error.
 
 This variable is typically used in a TRAP routine,
 where the error number is taken from {\bf ER}.
@@ -2303,7 +2200,7 @@ where the error number is taken from {\bf ER}.
 \begin{description}[leftmargin=3cm,style=nextline]
 \item [Token:] \$D3
 \item [Format:] {\bf ERR\$(number)}
-\item [Usage:] The {\bf ERR\$} function is used to convert
+\item [Usage:] Used to convert
                an error number to an error string.
 
    {\bf number} is a BASIC error number (1 -> 41).
@@ -2332,7 +2229,7 @@ where the error number is taken from the reserved variable {\bf ER}.
 \begin{description}[leftmargin=3cm,style=nextline]
 \item [Token:] \$FD
 \item [Format:] {\bf EXIT}
-\item [Usage:] The {\bf EXIT} exits the current {\bf DO .. LOOP}
+\item [Usage:] Exits the current {\bf DO .. LOOP}
                and continues execution at the first
                statement after the next {\bf LOOP} statement.
 
@@ -2390,7 +2287,7 @@ PRINT EXP(LOG(2))
 \begin{description}[leftmargin=3cm,style=nextline]
 \item [Token:] \$FE \$25
 \item [Format:] {\bf FAST}
-\item [Usage:] The {\bf FAST} commands sets the system speed
+\item [Usage:] Sets the system speed
                to maximum (3.58 MHz).
                The system default is {\bf FAST}.
                However after using {\bf SLOW} for access to
@@ -2414,7 +2311,7 @@ PRINT EXP(LOG(2))
 \begin{description}[leftmargin=3cm,style=nextline]
 \item [Token:] \$FE \$03
 \item [Format:] {\bf FILTER [freq, lp, bp, hp, res]}
-\item [Usage:] The {\bf FILTER} command sets
+\item [Usage:] Sets
                the parameters for soundfilter.
 
       {\bf freq} = filter cut off frequency (0 -> 2047)
@@ -2568,12 +2465,12 @@ RUN
 \begin{description}[leftmargin=3cm,style=nextline]
 \item [Token:] \$FE \$39
 \item [Format:] {\bf FOREGROUND colour}
-\item [Usage:] The {\bf FOREGROUND} command sets the foreground colour
+\item [Usage:] Sets the foreground colour
                (text colour) of the screen to the argument,
                which must be in the
                range 0 to 15. (See colour table).
 \item [Example:] \screentext{FOREGROUND  7} - select foreground colour yellow.
-\item [Colours:] {\bf Index and RGB values of colour pallette}
+\item [Colours:] {\bf Index and RGB values of colour palette}
 
 \ttfamily
 {\setlength{\tabcolsep}{1mm}
@@ -2611,7 +2508,7 @@ RUN
 \begin{description}[leftmargin=3cm,style=nextline]
 \item [Token:] \$B8
 \item [Format:] {\bf FRE(mode)}
-\item [Usage:] The {\bf FRE} function returns the number of free
+\item [Usage:] Returns the number of free
                bytes for modes 0 and 1.
 
                {\bf FRE(0)} returns the number of free bytes in
@@ -2648,7 +2545,7 @@ RUN
 \begin{description}[leftmargin=3cm,style=nextline]
 \item [Token:] \$A1
 \item [Format:] {\bf GET string variable}
-\item [Usage:] The {\bf GET} command gets the next character
+\item [Usage:] Gets the next character
                from the keyboard queue. If the queue is empty
                a null string is assigned to the variable,
                otherwise a one character string is created
@@ -2685,7 +2582,7 @@ RUN
 \begin{description}[leftmargin=3cm,style=nextline]
 \item [Token:] \$A1 '\#'
 \item [Format:] {\bf GET\# channel, list of string variables}
-\item [Usage:] The {\bf GET\#} command reads as many bytes
+\item [Usage:] Reads as many bytes
                as necessary from the channel argument
                and assigns strings of length one to
                each variable in the list.
@@ -2723,7 +2620,7 @@ RUN
 \begin{description}[leftmargin=3cm,style=nextline]
 \item [Token:] \$A1 \$F9 (GET token and KEY token)
 \item [Format:] {\bf GETKEY string variable}
-\item [Usage:] The {\bf GETKEY} command gets the next character
+\item [Usage:] Gets the next character
                from the keyboard queue. If the queue is empty
                the program waits until a key is hit.
                Then a one character string is created
@@ -2755,7 +2652,7 @@ RUN
 \begin{description}[leftmargin=3cm,style=nextline]
 \item [Token:] \$CB \$36 \$34 (GO token and 64 )
 \item [Format:] {\bf GO64}
-\item [Usage:] The {\bf GO64} command switches the
+\item [Usage:] Switches the
                computer to the C64 compatible mode.
                In direct mode a security prompt
                "ARE YOU SURE?" is printed, which must
@@ -2793,7 +2690,7 @@ ARE YOU SURE?
 \item [Remarks:] Unlike other programming languages, this BASIC
                version does not support arguments or local
                variables for subroutines. \\
-               Programs can be optimzed by grouping subroutines
+               Programs can be optimised by grouping subroutines
                at the beginning of the program source. The
                {\bf GOSUB} calls will then have low line numbers
                with only few digits to decode. Also the subroutines
@@ -2827,8 +2724,7 @@ ARE YOU SURE?
 \item [Token:] \$89 (GOTO) or \$CB \$A4 (GO TO)
 \item [Format:] {\bf GOTO line} \\
                 {\bf GO TO line}
-\item [Usage:] The {\bf GOTO}
-               command continues program
+\item [Usage:] Continues program
                execution at the given BASIC line number.
                The {\bf GOTO} command written as a single
                word executes faster than the {\bf GO TO} command.
@@ -2839,7 +2735,7 @@ ARE YOU SURE?
                search starts from the current line upwards.
                If the target line number is lower, the search starts
                from the start of the program.
-               Knowing this mechanism it is possible to optimze
+               Knowing this mechanism it is possible to optimise
                the runtime by grouping often used targets at the
                start of the program.
 
@@ -2870,8 +2766,7 @@ ARE YOU SURE?
 \begin{description}[leftmargin=3cm,style=nextline]
 \item [Token:] \$DE
 \item [Format:] {\bf GRAPHIC CLR}
-\item [Usage:] The {\bf GRAPHIC CLR}
-               command initializes the BASIC graphic system.
+\item [Usage:] Initialises the BASIC graphic system.
                It clears the graphics memory and screen and sets
                all parameters of the graphics context to the
                default values.
@@ -2900,21 +2795,16 @@ ARE YOU SURE?
 \item [Token:] \$F1
 \item [Format:] {\bf HEADER diskname [,Iid] [,D drive] [,U unit] }
 \item [Usage:]
-   The {\bf HEADER} command is used to format or clear a diskette
+   Used to format or clear a diskette
    or disk.
 
    {\bf diskname} is either a quoted string, e.g. {\bf "data"} or
    a string expression in parentheses, e.g. {\bf (DN\$)}
    The maximum length of the diskname is 16 characters.
 
-   {\bf drive} = drive \# in dual drive disk units. \\
-   The drive \# defaults to 0 and can be omitted on single drive units
-   like the 1581, 1571 or 1541 series.
+   \drivedefinition
 
-   {\bf unit} = device number on the IEC bus.
-   The number is typically in the range 8-11 for disk units.
-   If a variable is used, it must be put in parentheses.
-   The unit \# defaults to 8.
+   \unitdefinition
 
 \item [Remarks:]
    For new diskettes or disks, which are not already formatted
@@ -2953,7 +2843,7 @@ ARE YOU SURE?
    and highlight the statement, that caused the error stop.
 
 \item [Remarks:]
-      {\bf HELP} displays BASIC errors. For errors in disk
+      Displays BASIC errors. For errors in disk
       I/O one should print the disk status variable {\bf DS}
       or the disk status string {\bf DS\$}.
 
@@ -2982,7 +2872,7 @@ The erroneous statement is highlighted or underlined like: \\
 \begin{description}[leftmargin=3cm,style=nextline]
 \item [Token:] \$D2
 \item [Format:] {\bf HEX\$(numeric expression)}
-\item [Usage:] The {\bf HEX\$} function returns a four
+\item [Usage:] Returns a four
                character string in hexadecimal notation
                converted from the argument.
                The argument must be in the range 0 -> 65535
@@ -3007,7 +2897,7 @@ PRINT HEX$(10),HEX$(100),HEX$(1000.9)
 \begin{description}[leftmargin=3cm,style=nextline]
 \item [Token:] \$FE \$39
 \item [Format:] {\bf HIGHLIGHT colour}
-\item [Usage:] The {\bf HIGHLIGHT} command sets the colour
+\item [Usage:] Sets the colour
                to be used for the "highlight" text attribute.
                The colour index must be in the
                range 0 to 15. (See colour table).
@@ -3015,7 +2905,7 @@ PRINT HEX$(10),HEX$(100),HEX$(1000.9)
                in listings generated by the {\bf HELP FIND CHANGE}
                commands.
 \item [Example:] \screentext{HIGHLIGHT  7} - select highlight colour yellow.
-\item [Colours:] {\bf Index and RGB values of colour pallette}
+\item [Colours:] {\bf Index and RGB values of colour palette}
 
 \ttfamily
 {\setlength{\tabcolsep}{1mm}
@@ -3053,7 +2943,7 @@ PRINT HEX$(10),HEX$(100),HEX$(1000.9)
 \begin{description}[leftmargin=3cm,style=nextline]
 \item [Token:] \$8B
 \item [Format:] {\bf IF expression THEN true clause ELSE false clause}
-\item [Usage:] The {\bf IF} keyword starts a conditional execution
+\item [Usage:] Starts a conditional execution
                statement.
 
                {\bf expression} is a logical or numeric expression.
@@ -3098,7 +2988,7 @@ PRINT HEX$(10),HEX$(100),HEX$(1000.9)
 \begin{description}[leftmargin=3cm,style=nextline]
 \item [Token:] \$85
 \item [Format:] {\bf INPUT [prompt <,|;>] variable list}
-\item [Usage:] The {\bf INPUT} command prints an optional
+\item [Usage:] Prints an optional
                prompt string and question mark to the screen,
                flashes the cursor and waits for user input
                from the keyboard.
@@ -3119,7 +3009,7 @@ PRINT HEX$(10),HEX$(100),HEX$(1000.9)
                type of input matching variable types.
                Also the number of input items must match the number
                of variables.
-               Entering non numeric charcaters for integer or real
+               Entering non numeric characters for integer or real
                variables will produce a TYPE MISMATCH ERROR.
                Strings for string variables have to be put in quotes
                if they contain spaces or commas. \\
@@ -3152,7 +3042,7 @@ PRINT HEX$(10),HEX$(100),HEX$(1000.9)
 \begin{description}[leftmargin=3cm,style=nextline]
 \item [Token:] \$84
 \item [Format:] {\bf INPUT\# chnannel, variable list}
-\item [Usage:] The {\bf INPUT\#} command reads a record
+\item [Usage:] Reads a record
                from an input device, e.g. a disk file
                or a RS232 device and assigns the read data
                to the variables in the list.
@@ -3169,7 +3059,7 @@ PRINT HEX$(10),HEX$(100),HEX$(1000.9)
 
 \item [Remarks:] The type and number of data in a record must
                match the variable list.
-               Reading non numeric charcaters for integer or real
+               Reading non numeric characters for integer or real
                variables will produce a FILE DATA ERROR.
                Strings for string variables have to be put in quotes
                if they contain spaces or commas. \\
@@ -3199,14 +3089,14 @@ PRINT HEX$(10),HEX$(100),HEX$(1000.9)
 \begin{description}[leftmargin=3cm,style=nextline]
 \item [Token:] \$D4
 \item [Format:] {\bf INSTR(haystack, needle [,start])}
-\item [Usage:] The {\bf INSTR} function locates the
+\item [Usage:] Locates the
                position of the string expression "needle"
                in the string expression "haystack" and
-               returns the index of the first occurence
+               returns the index of the first occurrence
                or zero, if there is no match.
 
                The string expression {\bf haystack}
-               is searched for the occurence of the
+               is searched for the occurrence of the
                string expression
                {\bf needle}.
 
@@ -3237,7 +3127,7 @@ PRINT HEX$(10),HEX$(100),HEX$(1000.9)
 \begin{description}[leftmargin=3cm,style=nextline]
 \item [Token:] \$B5
 \item [Format:] {\bf INT(numeric expression)}
-\item [Usage:] The {\bf INT} function searches the greatest
+\item [Usage:] Searches the greatest
                integer value, that is less or equal to the argument
                and returns this value as a real number.
                This function is {\bf NOT} limited to the typical
@@ -3245,7 +3135,7 @@ PRINT HEX$(10),HEX$(100),HEX$(1000.9)
                it uses real arithmetic. The allowed range is
                therefore determined by the size of the real
                mantissas \\
-               (32 bit) : (-2147483648 -> 2147483647).
+               (32-bit) : (-2147483648 -> 2147483647).
 
 \item [Remarks:] It is not necessary to use the {\bf INT}
                function for assigning real values to integer
@@ -3270,10 +3160,10 @@ PRINT HEX$(10),HEX$(100),HEX$(1000.9)
 \begin{description}[leftmargin=3cm,style=nextline]
 \item [Token:] \$CF
 \item [Format:] {\bf JOY(port)}
-\item [Usage:] The {\bf JOY} function returns the state of the
+\item [Usage:] Returns the state of the
                joystick for the selected port (1 or 2).
                Bit 7 contains the state of the fire button.
-               The stick can be moved to 8 directions, which
+               The stick can be moved in eight directions, which
                are numbered clockwise starting at the upper position.
 
 \ttfamily
@@ -3376,7 +3266,7 @@ RUN    & 16 & "RUN"+CHR\$(34)+"*"+CHR\$(34)+CHR\$(13) \\
 \begin{description}[leftmargin=3cm,style=nextline]
 \item [Token:] \$C8
 \item [Format:] {\bf LEFT\$(string, n)}
-\item [Usage:] The {\bf LEFT\$} function returns a string
+\item [Usage:] Returns a string
                containing the first {\bf n} characters from the
                argument {\bf string}.
                If the length of {\bf string} is equal or less than {\bf n},
@@ -3404,7 +3294,7 @@ MEGA
 \begin{description}[leftmargin=3cm,style=nextline]
 \item [Token:] \$C3
 \item [Format:] {\bf LEN(string)}
-\item [Usage:] The {\bf LEN} function returns the length of the string.
+\item [Usage:] Returns the length of the string.
 
                {\bf string} = a string expression
 
@@ -3447,7 +3337,7 @@ A=5      :REM SHORTER AND FASTER
 \begin{description}[leftmargin=3cm,style=nextline]
 \item [Token:] \$E5
 \item [Format:] {\bf LINE xbeg,ybeg,xend,yend}
-\item [Usage:] The {\bf LINE} statement draws a line on the current
+\item [Usage:] Draws a line on the current
                graphics screen from the coordinate (xbeg/ybeg) to
                the coordinate (xend/yend). All currently defined
                modes and values of the graphic context are used.
@@ -3471,7 +3361,7 @@ A=5      :REM SHORTER AND FASTER
 \begin{description}[leftmargin=3cm,style=nextline]
 \item [Token:] \$9B
 \item [Format:] {\bf LIST [line range]} \\
-\item [Usage:] The {\bf LIST} command is used to list
+\item [Usage:] Used to list
                a range of lines from the BASIC program.
 
                {\bf line range} consist of the first and the last
@@ -3512,10 +3402,7 @@ A=5      :REM SHORTER AND FASTER
    {\bf filename} is either a quoted string, e.g. {\bf "prog"} or
    a string expression.
 
-   {\bf unit} = device number on the IEC bus.
-   The number is typically in the range 8-11 for disk units.
-   If a variable is used, it must be put in parentheses.
-   The unit \# defaults to 8.
+   \unitdefinition
 
    If {\bf flag} has a non zero value, the file is loaded to
    the address, which is read from the first two bytes of the file.
@@ -3543,7 +3430,7 @@ A=5      :REM SHORTER AND FASTER
 \begin{description}[leftmargin=3cm,style=nextline]
 \item [Token:] \$E6
 \item [Format:] {\bf LOCATE x,y}
-\item [Usage:] The {\bf LOCATE} moves the graphical cursor to
+\item [Usage:] Moves the graphical cursor to
                the specified position on the current graphic screen.
 
 \item [Remarks:] The graphical cursor is not visible, it's just
@@ -3565,7 +3452,7 @@ A=5      :REM SHORTER AND FASTER
 \begin{description}[leftmargin=3cm,style=nextline]
 \item [Token:] \$BC
 \item [Format:] {\bf LOG}(numeric expression)
-\item [Usage:] The {\bf LOG} (LOGarithm) function computes
+\item [Usage:] Computes
                the value of the natural logarithm of the argument.
                The natural logarithm uses
                Euler's number {\bf e = 2.71828183} as base,
@@ -3652,7 +3539,7 @@ PRINT LOG(100) / LOG(10)
                {\bf LPEN(1)} returns the Y position of the lightpen,
                the range is 50 -> 250.
 
-\item [Remarks:] The X resolution is 2 pixel, {\bf LPEN(0)} returns
+\item [Remarks:] The X resolution is two pixels, {\bf LPEN(0)} returns
                  therefore only even numbers.
                  A bright background colour is needed to trigger
                  the lightpen. The {\bf COLLISION} statement may
@@ -3707,7 +3594,7 @@ MEGA+65
 \begin{description}[leftmargin=3cm,style=nextline]
 \item [Token:] \$FA
 \item [Format:] {\bf MONITOR}
-\item [Usage:]  The {\bf MONITOR} calls the machine language
+\item [Usage:]  Calls the machine language
                 monitor program, which is mainly used for
                 debugging.
 
@@ -3731,7 +3618,7 @@ MEGA+65
 \item [Token:] \$FE \$3E
 \item [Format:] {\bf MOUSE ON [,port [,sprite [,pos]]]} \\
                 {\bf MOUSE OFF}
-\item [Usage:]  The {\bf MOUSE ON} command enables the mouse driver
+\item [Usage:]  Enables the mouse driver
                 and connects the mouse at the specified port
                 with the mouse pointer sprite.
 
@@ -3739,7 +3626,7 @@ MEGA+65
 
                 {\bf sprite} = sprite number for mouse pointer (default 0).
 
-                {\bf pos} = intial mouse position (x,y).
+                {\bf pos} = initial mouse position (x,y).
 
                 The {\bf MOUSE OFF} command disables the mouse
                 driver and frees the associated sprite.
@@ -3766,7 +3653,7 @@ MEGA+65
 \item [Format:] {\bf MOVSPR sprite, x, y} \\
                 {\bf MOVSPR sprite, <+|->xrel, <+|->yrel} \\
                 {\bf MOVSPR sprite, angle \# speed}
-\item [Usage:]  The {\bf MOVSPR} performs, depending on the argument
+\item [Usage:]  {\bf MOVSPR} performs, depending on the argument
                 format, three different tasks:
 
                 The first form {\bf MOVSPR sprite, x, y} uses no
@@ -3818,7 +3705,7 @@ MEGA+65
 \item [Token:] \$A2
 \item [Format:] {\bf NEW} \\
                 {\bf NEW RESTORE}
-\item [Usage:]  The {\bf NEW} resets all BASIC parameters
+\item [Usage:]  Resets all BASIC parameters
                 to their default values.
                 After {\bf NEW} the maximum RAM is available
                 for program and data storage.
@@ -3829,7 +3716,7 @@ MEGA+65
                 before {\bf NEW}, it is possible to recover the
                 program. If there were no {\bf LOAD} operations
                 or editing after the {\bf NEW} command, the program
-                can bes restored with the command \\
+                can be restored with the command \\
                 {\bf NEW RESTORE}.
 \item [Example:] Using {\bf NEW}:
 \begin{screenoutput}
@@ -3847,7 +3734,7 @@ MEGA+65
 \begin{description}[leftmargin=3cm,style=nextline]
 \item [Token:] \$82
 \item [Format:] {\bf FOR index=start TO end [STEP step] ... NEXT [index]}
-\item [Usage:] The {\bf NEXT} statement terminates the definition
+\item [Usage:] Terminates the definition
                of a BASIC loop with an index variable.
 
                The {\bf index} variable may be incremented or decremented
@@ -3899,7 +3786,7 @@ MEGA+65
 \begin{description}[leftmargin=3cm,style=nextline]
 \item [Token:] \$A8
 \item [Format:] {\bf NOT} operand
-\item [Usage:]  The boolean {\bf NOT} operator performs a bitwise
+\item [Usage:]  Performs a bitwise
                 logical NOT operation on a 16 bit value.
                 Integer operands are used as they are.
                 Real operands are converted to a signed 16 bit integer.
@@ -3972,7 +3859,7 @@ In most cases the {\bf NOT} will be used in {\bf IF} statements.
                 either a computed {\bf GOSUB} or {\bf GOTO} statement.
                 Dependent on the value of the expression, the target
                 for the {\bf GOSUB} or {\bf GOTO} is chosen from
-                the table of line addresses at the end of the statemnt.
+                the table of line addresses at the end of the statement.
 
                 As a secondary keyword, {\bf ON} is used in
                 combination with primary keywords like
@@ -3982,7 +3869,7 @@ In most cases the {\bf NOT} will be used in {\bf IF} statements.
                 Real values are cut to integer.
 
                 {\bf line list} is a comma separated list of valid
-                linenumbers.
+                line numbers.
 
 \item [Remarks:] Negative values for {\bf expression} will stop
                  the program with an error message.
@@ -4023,7 +3910,7 @@ In most cases the {\bf NOT} will be used in {\bf IF} statements.
 \item [Format:]
   {\bf OPEN lfn, first address [,secondary address [,filename]]}
 \item [Usage:]
-   The {\bf OPEN} command opens an input/output channel for
+   Opens an input/output channel for
    a device.
 
    {\bf lfn} = {\bf l}ogical {\bf f}ile {\bf n}umber \\
@@ -4087,11 +3974,11 @@ In most cases the {\bf NOT} will be used in {\bf IF} statements.
 \begin{description}[leftmargin=3cm,style=nextline]
 \item [Token:] \$B0
 \item [Format:] operand {\bf OR} operand
-\item [Usage:]  The boolean {\bf OR} operator performs a bitwise
-                logical OR operation on two 16 bit values.
+\item [Usage:]  Performs a bitwise
+                logical OR operation on two 16-bit values.
                 Integer operands are used as they are.
-                Real operands are converted to a signed 16 bit integer.
-                Logical operands are converted to 16 bit integer
+                Real operands are converted to a signed 16-bit integer.
+                Logical operands are converted to 16-bit integer
                 using \$FFFF, decimal -1 for TRUE
                 and \$0000, decimal 0, for FALSE.
 
@@ -4131,7 +4018,7 @@ In most cases the {\bf OR} will be used in {\bf IF} statements.
 \begin{description}[leftmargin=3cm,style=nextline]
 \item [Token:] \$DF
 \item [Format:] {\bf PAINT x, y, mode [,colour]}
-\item [Usage:]  The {\bf PAINT} command performs a flood fill
+\item [Usage:]  Performs a flood fill
                 of an enclosed graphics area.
 
                 {\bf x, y} is a coordinate pair, which must
@@ -4156,4 +4043,3 @@ In most cases the {\bf OR} will be used in {\bf IF} statements.
 100 SCREEN CLOSE 1       :REM END GRAPHICS
 \end{screenoutput}
 \end{description}
-

--- a/basic-fragments.tex
+++ b/basic-fragments.tex
@@ -1,0 +1,17 @@
+\def\drivedefinition{
+{\bf drive} = drive \# in dual drive disk units. \\
+The drive \# defaults to 0 and can be omitted on single drive units
+like the 1581, 1571 or 1541 series.
+}
+
+\def\unitdefinition{
+{\bf unit} = device number on the IEC bus.
+Typically in the range 8 to 11 for disk units.
+If a variable is used, it must be put in parentheses.
+The unit \# defaults to \screentext{8}.
+}
+
+\def\filenamedefinition{
+{\bf filename} is either a quoted string, e.g. {\bf "data"} or
+a string expression in parentheses, e.g. {\bf (FN\$)}
+}

--- a/element-catalogue.tex
+++ b/element-catalogue.tex
@@ -83,6 +83,8 @@ Text to the left \specialkey{RUN STOP} and text to the right.
 RUN
 \end{screenoutput}
 
+Use the "screentext" macro to perform inline screen text:
+\screentext{?SYNTAX ERROR}
 
 \section{Sprite Grids}
 \subsection{Original Commodore Balloon Demo}

--- a/elements/screenoutput.tex
+++ b/elements/screenoutput.tex
@@ -1,5 +1,5 @@
-% This is an element for displaying output from the Mega65 screen.
-% It can display program code or to show activity on the screen.
+% This is a collection of elements for displaying output from the Mega65 screen.
+% They can display program code or fragments to show activity on the screen.
 % Example of use:
 %
 %    \begin{screenoutput}
@@ -16,6 +16,11 @@
 %
 %    RUN
 %    \end{screenoutput}
+%
+% for inline display of code, use:
+%
+%    \screentext{?SYNTAX ERROR}
+%
 
 \usepackage{listings,color}
 
@@ -43,4 +48,3 @@
 
 % For in-line screen text
 \newcommand{\screentext}[1]{ {\codefont\color{black}\normalsize{#1}} }
-

--- a/gettingstarted.tex
+++ b/gettingstarted.tex
@@ -2,11 +2,11 @@
 \phantomsection
 \section{Keyboard}
 
-Now that you have everything connected, it is time to get familiar with the Mega65 keyboard.
+Now that you have everything connected, it's time to get familiar with the Mega65 keyboard.
 
-You will notice that the keyboard is a little different from the modern standard used on computers today. While most keys will be in familar positions, there are some specialised keys with special graphic symbols marked on the front.
+You may notice that the keyboard is a little different from the standard used on computers today. While most keys will be in familar positions, there are some specialised keys with special graphic symbols marked on the front.
 
-What follows is a brief description of how some of these special keys function.
+Here's a brief description of how some of these special keys function.
 
  \vspace*{1cm}
 
@@ -18,7 +18,7 @@ The \megakey{Return} key tells the computer to process the information you typed
 
 \megakey[title]{Shift}
 
-The \megakey{Shift} key works just like on a typewriter or modern keyboard. It allows you to type uppercase letters when in lowercase mode, or to gain access to special graphic characters that are displayed on the right hand side of the front part of the key.
+The \megakey{Shift} key works just like on a modern keyboard. It allows you to type uppercase letters when in lowercase mode, or to gain access to special graphic characters that are displayed on the right hand side of the front part of the key.
 
 In the case of the function keys, pressing \megakey{Shift} will give you the function that is marked at the front of the key.
 

--- a/howcomputerswork.tex
+++ b/howcomputerswork.tex
@@ -2,29 +2,24 @@
 
 Computers can do amazing things, and you can make them do amazing things for you, too.
 But to do that, you need to understand how computers work.  This can be hard to find
-out these days, because computers are now so complicated, that it isn't obvious how
-computers work anymore, just by looking at them and using them.  The MEGA65 is designed
+out these days, because computers are now so complicated that it isn't obvious just by looking at them and using them.  The MEGA65 is designed
 to be simple enough that you can learn how computers work as you use it.  But we don't
-want to leave you to have to work out everything for yourself.  That is why we have
-written this chapter, so that you can learn how computers work, and then use that knowledge
+want to leave you to have to work out everything for yourself.  This chapter will help you to understand how computers work, and then use that knowledge
 to help you make computers do what \emph{you} want them to do.
 
 \phantomsection
 \section{Computers are just a pile of switches}
 
 What are computers \emph{really}? Well, the answer to that question is quite simple, if a little
-surprising: Computers really are just made of lots of switches.  These switches work very similar
-to the switches you use to turn a light on or off.  Light switches connect or disconnect the
+surprising: Computers really are just made of lots of switches.  These switches work like the switches you use to turn a light on or off.  Light switches connect or disconnect the
 power supply to a light.  The switches in computers connect or disconnect circuits in the computer
-to power. But computers can do a lot more than just turn on and off, so something else must be
+to power. But computers can do a lot more than just switch on and off, so something else must be
 going on. That something else is also a bit of a surprise: A computer can turn its own switches
 on and off by itself.  Let's explore how this simple idea of switches that can turn themselves on
 and off makes a computer.
 
-As we have just heard, computers are full of switches.  Obviously those switches must be tiny, and they
-are.  When you hear people talking about microns and nanometres with regard to computers, they are often
+Computers are full of switches. When you hear people talking about microns and nanometres with regard to computers, they are often
 talking about the size of the little switches that make up the computer chips.  These switches are called
 transistors. The switches in the main
-chip of the MEGA65, for example, are 28 nanometres long.  That's about 100,000 times skinnier than a single
+chip of the MEGA65, for example, are 28 nanometres long.  That's about 100,000 times thinner than a single
 strand of hair.  This is good, because a computer might need millions or billions of switches in its design.
-

--- a/introduction.tex
+++ b/introduction.tex
@@ -1,33 +1,31 @@
 \chapter{Introduction}
 
-Congratulations on your purchase of one of the most long awaited computers in the history of computing!
-The {\bf MEGA65} is a community designed computer, based on the never-released Commodore{\texttrademark}
+Congratulations on your purchase of one of the most long-awaited computers in the history of computing.
+The MEGA65 is a community designed computer, based on the never-released Commodore{\textregistered}
 65\footnote{Commodore is a trademark of C= Holdings} computer, that was first designed in
-1989, and intended for public release in 1990.  Twenty eight years have passed since then,
-but the {\bf simple}, {\bf friendly} nature of the 1980s home computers is still something that has not
-been recreated.  These were computers that were simple enough you could understand not just
-how your computer worked, but how computers themselves work.
+1989, and intended for public release in 1990.  Twenty-eight years have passed since then,
+but the simple, friendly nature of the 1980s home computers is still something that hasn't
+been recreated.  These were computers that were simple enough that you could understand not just
+how to work with your computer, but how computers themselves work.
 
 Many of the people who grew
-up using the home computers of the 1980s have grown up to have exciting and rewarding jobs in many companies,
+up using the home computers of the 1980s now have exciting and rewarding jobs in many companies,
 in part because of what they learnt about computers in the comfort of their own home.  We
-want to give you that same opportunity, so that you can experience the joy of learning how
-to use computers to solve all sorts of problems, whether that be writing a letter to a friend,
-working out how much tax you owe, inventing new things, or working out how the universe works.
+want to give you that same opportunity, to experience the joy of learning how
+to use computers to solve all sorts of problems: writing a letter to a friend,
+working out how much tax you owe, inventing new things, or discovering how the universe works.
 This is why we made the {\bf MEGA65}.
 
-The {\bf MEGA65} team thinks that owning a computer should
-be like owning a house: You don't just use a house, you change things big and small to really
+The MEGA65 team thinks that owning a computer should
+be like owning a home: You don't just use a home, you change things big and small to really
 make it your own, and maybe even renovate it or add on a room or two.  In this guide we will
 show you how to more than just hang your own pictures on the wall, but instead how you can dream
 up new ways of using the powerful capabilities of computers by coding your own computer programmes,
 and even changing the computer itself!
 
-To help you have fun with your {\bf MEGA65}, we will show you how to use the exciting {\bf graphics} and {\bf sound}
-capabilities of the {\bf MEGA65}.  But the {\bf MEGA65} isn't just about writing your own programmes.
+To help you have fun with your MEGA65, we will show you how to use the exciting {\bf graphics} and {\bf sound}
+capabilities of the MEGA65.  But the MEGA65 isn't just about writing your own programmes.
 It can also run many of the thousands of games and other programmes that were created for the
-Commodore 64{\texttrademark}\footnote{Commodore 64 is a trademark of C= Holdings, } computer.
+Commodore{\textregistered} 64{\texttrademark}\footnote{Commodore 64 is a trademark of C= Holdings, } computer.
 
 Welcome to the world of the {\bf MEGA65}!
-
-

--- a/mega65-book.tex
+++ b/mega65-book.tex
@@ -134,6 +134,7 @@
 
 	\include{appendix-accessories}
 	\include{appendix-basic2}
+	\include{basic-fragments}
 	\include{appendix-basic10}
 	\include{appendix-basicabbreviations}
 	\include{appendix-screencodes}

--- a/settingup.tex
+++ b/settingup.tex
@@ -2,21 +2,21 @@
 \phantomsection
 \section{Unpacking and connecting the MEGA65}
 
-The following instructions will show you all of the steps required to setup your MEGA65 home computer.
-The MEGA65 computer comes with the following:
+This section describes how to set up your MEGA65 home computer.
+The box contains with the following:
 \begin{itemize}
-\item MEGA65 computer
-\item Power supply (black box with socket for mains supply)
-\item This book, the MEGA65 User's Guide
+\item MEGA65 computer.
+\item Power supply (black box with socket for mains supply).
+\item This book, the MEGA65 User's Guide.
 \end{itemize}
 
-In addition, you will need the following things to be able to use your MEGA65 computer:
+In addition, to be able to use your MEGA65 computer:
 \begin{itemize}
 \item A television set or computer monitor with a VGA input, that is capable of displaying an image with 800x600 pixel resolution at 60Hz, and preferably also at 50Hz.
 \item A VGA video cable.
 \end{itemize}
 
-You may also wish to use the following to get the most out of your MEGA65:
+You may also want to use the following to get the most out of your MEGA65:
 \begin{itemize}
 \item 3.5" audio cable and suitable speakers or hifi system, so that you can enjoy the sound capabilities of your MEGA65.
 \item RJ45 ethernet cable (``normal network cable'') and a network router or switch that it can connect to, so that you can use the high-speed networking capabilities of your MEGA65.

--- a/userguide.tex
+++ b/userguide.tex
@@ -34,7 +34,7 @@
   \vfill
   WORK IN PROGRESS
 
-  \index{copyright}Copyright \copyright 2018 by Paul Gardner-Stephen, Flinders University, the Museum of Electronic Games and Art eV., and contributors.
+  \index{copyright}Copyright \copyright 2019 by Paul Gardner-Stephen, Flinders University, the Museum of Electronic Games and Art eV., and contributors.
 
   This user guide is made available under the GNU Free Documentation License v1.3, or later, if desired. This means that you are free to modify, reproduce
   and redistribute this user guide, subject to certain conditions. The full text of the GNU Free Documentation License v1.3 can be
@@ -130,6 +130,7 @@
 
   \include{appendix-accessories}
   \include{appendix-basic2}
+	\include{basic-fragments}
   \include{appendix-basic10}
   \include{appendix-basicabbreviations}
   \include{appendix-screencodes}


### PR DESCRIPTION
BASIC 10 text changes
Some typo corrections
Moved common blocks from the BASIC text into a fragments file.

Not all suggestions were implemented, for example: formatting styles, internationalisation, some suggestions and so forth.

How ironic that this review was way better than my own command of the English language.
Mind you, not to suggest that Australian English can really be classed as English.
Certainly not to the standard that Her Majesty would expect.