### PR TITLE
Add missing CHR$ codes, use \screentext and use multicols for table

### DIFF
--- a/appendix-asciicodes.tex
+++ b/appendix-asciicodes.tex
@@ -6,124 +6,213 @@
 
 \label{appendix:asciicodes}
 
-You can use the PRINT CHR\$(X) statement to print a character.
-Below is the full table of ASCII codes you can print by index.
-For example, by using index 65 from the table below as:
-PRINT CHR\$(65) you will print the letter 'A'.
+You can use the \screentext{PRINT CHR\$(X)} statement to print a character.
+Below is the full table of ASCII codes you can print by index.  For example, by
+using index 65 from the table below as: \screentext{PRINT CHR\$(65)} you will
+print the letter \screentext{A}.
 
-You can also do the reverse with the ASC statement.
-For example:
-PRINT ASC("A")
-Will output 65, which matches in the ASCII code table.
-
-
-\begin{center}
-\setlength{\def\arraystretch{1.5}\tabcolsep}{6pt}
-\begin{longtable}{ c c | c c  | c c}
-	\textbf{CHR\$} & \textbf{Prints} & \textbf{CHR\$} & \textbf{Prints} & \textbf{CHR\$} & \textbf{Prints}\\
-  \hline
-	\endhead
-
-	 0	& 								&	17	&	\megakey{$\downarrow$}		& 34	&	" \\
-	 1	&									&	18	& \specialkey{RVS ON}						& 35	&	\# \\
-	 2	&									&	19	& \specialkey{CLR HOME}					& 36	& \$ \\
-	 3	&									& 20	& \specialkey{INST DEL}					& 37	& \% \\
-	 4	&									& 21	& 													& 38	& \& \\
-	 5	& \megakey{WHT}		& 22	&														& 39	& ' \\
-	 6	& 								& 23	&														& 40	& ( \\
-	 7	&									& 24	&														& 41	& ) \\
-	 8	&	\multicolumn{1}{r|}{\small{DISABLE} \specialkey{SHIFT}\megasymbolkey}								& 25	&														& 42	& * \\
-	 9	&	\multicolumn{1}{r|}{\small{ENABLE} \specialkey{SHIFT}\megasymbolkey}								& 26	&														& 43	& + \\
-	10	&									& 27	&														& 44	& , \\
-	11	&									& 28	& \megakey{RED}							& 45	& - \\
-	12	&									& 29	&	\megakey{$\rightarrow$}		&	46	& . \\
-	13	&	\megakey{RETURN}& 30	& \megakey{GRN}							& 47	& / \\
-	14	&	\small{LOWER CASE}			& 31	& \megakey{BLU}							& 48	& 0 \\
-	15	&									& 32	& \megakey{SPACE}						& 49	& 1 \\
-	16	&									& 33	& !													& 50	& 2 \\
-
-\end{longtable}
-\end{center}
+You can also do the reverse with the ASC statement.  For example:
+\screentext{PRINT ASC("A")} will output \screentext{65}, which matches with the
+code in the table.
 
 
-\newpage
-
-
-
-\begin{center}
-\setlength{\def\arraystretch{1.5}\tabcolsep}{6pt}
-\begin{longtable}{ c c | c c  | c c}
-	\textbf{CHR\$} & \textbf{Prints} & \textbf{CHR\$} & \textbf{Prints} & \textbf{CHR\$} & \textbf{Prints}\\
-  \hline
-	\endhead
-
-	51	&	3		&	75	&	K					&	99	& \graphicsymbol{C}\\
-	52	&	4		&	76	&	L					&	100	& \graphicsymbol{D}\\
-	53	&	5		&	77	&	M					&	101	& \graphicsymbol{E}\\
-	54	&	6		&	78	&	N					&	102	& \graphicsymbol{F}\\
-	55	&	7		&	79	&	O					&	103	& \graphicsymbol{G}\\
-	56	&	8		&	80	& P						&	104	& \graphicsymbol{H}\\
-	57	&	9		&	81	& Q						&	105	& \graphicsymbol{I}\\
-	58	&	:		&	82	& R						&	106	& \graphicsymbol{J}\\
-	59	&	;		&	83	& S						&	107	& \graphicsymbol{K}\\
-	60	&	<		&	84	& T						&	108	& \graphicsymbol{L}\\
-	61	&	=		&	85	& U						&	109	& \graphicsymbol{M}\\
-	62	&	>		&	86	& V						&	110	& \graphicsymbol{N}\\
-	63	&	?		&	87	& W						&	111	& \graphicsymbol{O}\\
-	64	&	@		&	88	& X						&	112	& \graphicsymbol{P}\\
-	65	&	A		&	89	& Y						&	113	& \graphicsymbol{Q}\\
-	66	&	B		&	90	& Z						&	114	& \graphicsymbol{R}\\
-	67	&	C		&	91	& [						&	115	& \graphicsymbol{S}\\
-	68	&	D		&	92	& \pounds				&	116	& \graphicsymbol{T}\\
-	69	&	E		&	93	& ]						&	117	& \graphicsymbol{U}\\
-	70	&	F		&	94	& $\uparrow$			&	118	& \graphicsymbol{V}\\
-	71	&	G		&	95	& $\leftarrow$			&	119	& \graphicsymbol{W}\\
-	72	&	H		&	96	& \graphicsymbol{C}		&	120	& \graphicsymbol{X}\\
-	73	&	I		&	97	& \graphicsymbol{A}		&	121	& \graphicsymbol{Y}\\
-	74	&	J		&	98	& \graphicsymbol{B}		&	122	& \graphicsymbol{Z}\\
-
-\end{longtable}
-\end{center}
-
-
-
-\newpage
-
-
-
-\begin{center}
-\setlength{\def\arraystretch{1.5}\tabcolsep}{6pt}
-\begin{longtable}{ c c | c c  | c c}
-	\textbf{CHR\$} & \textbf{Prints} & \textbf{CHR\$} & \textbf{Prints} & \textbf{CHR\$} & \textbf{Prints}\\
-  \hline
-	\endhead
-	123	& \graphicsymbol{+} 				& 146	&	\specialkey{RVS OFF}	&  169	& \graphicsymbol{?}\\
-	124	& \graphicsymbol{-} 				& 147	&	\specialkey{CLR HOME}	&  170	& \graphicsymbol{v}\\
-	125	& \graphicsymbol{B} 				& 148	&	\specialkey{INST DEL}	&  171	& \graphicsymbol{q}\\
-	126	& \graphicsymbol{\textbackslash}	& 149	&	\graphicsymbol{U}	&  172	& \graphicsymbol{d}\\
-	127	& \graphicsymbol{]} 				& 150	&	\graphicsymbol{V}	&  173	& \graphicsymbol{z}\\
-	128	& 									& 151	&	\graphicsymbol{W}	& 174	& \graphicsymbol{s}\\
-	129	& \megakey{ORG} 					& 152	&	\graphicsymbol{X}	& 175	& \graphicsymbol{n}\\
-	130	&  									& 153	&	\graphicsymbol{Y}	& 176	& \graphicsymbol{a}\\
-	131	&  									& 154	&	\graphicsymbol{Z}	& 177	& \graphicsymbol{e}\\
-	132	&  									& 155	&	\graphicsymbol{+}	& 178	& \graphicsymbol{r}\\
-	133	& F1 								& 156	& \megakey{PUR}			& 179	& \graphicsymbol{w}\\
-	134	& F3 								& 157	& \megakey{$\leftarrow$}& 180	& \graphicsymbol{h}\\
-	135	& F5 								& 158	& \megakey{YEL}			& 181	& \graphicsymbol{j}\\
-	136	& F7 								& 159	& \megakey{CYN}			& 182	& \graphicsymbol{l}\\
-	137	& F2 								& 160	& \megakey{Space}		& 183	& \graphicsymbol{y}\\
-	138	& F4								& 161	& \graphicsymbol{k}		& 184	& \graphicsymbol{u}\\
-	139	&	F6								& 162	& \graphicsymbol{i}		& 185	& \graphicsymbol{p}\\
-	140	&	F8								& 163	& \graphicsymbol{t}		& 186	& \graphicsymbol{\{}\\
-	141	&	\specialkey{SHIFT}\megakey{return}	& 164	& \graphicsymbol{[}		& 187	& \graphicsymbol{f}\\
-	142	&	\small{UPPERCASE}	& 165	& \graphicsymbol{g}		& 188	& \graphicsymbol{c}\\
-	143	&									& 166	& \graphicsymbol{=}		& 189	& \graphicsymbol{x}\\
-	144	& \megakey{BLK}						& 167	& \graphicsymbol{m}		& 190	& \graphicsymbol{v}\\
-	145	&	\megakey{$\uparrow$}			& 168	& \graphicsymbol{/}		& 191	& \graphicsymbol{b}\\
-
-\end{longtable}
-\end{center}
-
+\begin{multicols}{4}
+\begin{description}[align=left,labelwidth=0.2cm]
+    \item [0]
+    \item [1]
+    \item [2]   \small{UNDERLINE ON}
+    \item [3]
+    \item [4]
+    \item [5]   \small{WHITE}
+    \item [6]
+    \item [7]   \small{BELL}
+    \item [8]   \footnotesize{DISABLE \specialkey{SHIFT}\megasymbolkey}
+    \item [9]   \footnotesize{ENABLE \specialkey{SHIFT}\megasymbolkey}
+    \item [10]  \small{LINEFEED}
+    \item [11]
+    \item [12]
+    \item [13]  \megakey{RETURN}
+    \item [14]  \small{LOWER CASE}
+    \item [15]  \small{BLINK ON}
+    \item [16]
+    \item [17]  \megakey{$\downarrow$}
+    \item [18]  \specialkey{RVS ON}
+    \item [19]  \specialkey{CLR HOME}
+    \item [20]  \specialkey{INST DEL}
+    \item [21]
+    \item [22]
+    \item [23]
+    \item [24]
+    \item [25]
+    \item [26]
+    \item [27]  \small{ESCAPE}
+    \item [28]  \small{RED}
+    \item [29]  \megakey{$\rightarrow$}
+    \item [30]  \small{GREEN}
+    \item [31]  \small{BLUE}
+    \item [32]  \megakey{SPACE}
+    \item [33]  !
+    \item [34]  "
+    \item [35]  \#
+    \item [36]  \$
+    \item [37]  \%
+    \item [38]  \&
+    \item [39]  '
+    \item [40]  (
+    \item [41]  )
+    \item [42]  *
+    \item [43]  +
+    \item [44]  ,
+    \item [45]  -
+    \item [46]  .
+    \item [47]  /
+    \item [48]  0
+    \item [49]  1
+    \item [50]  2
+    \item [51]  3
+    \item [52]  4
+    \item [53]  5
+    \item [54]  6
+    \item [55]  7
+    \item [56]  8
+    \item [57]  9
+    \item [58]  :
+    \item [59]  ;
+    \item [60]  <
+    \item [61]  =
+    \item [62]  >
+    \item [63]  ?
+    \item [64]  @
+    \item [65]  A
+    \item [66]  B
+    \item [67]  C
+    \item [68]  D
+    \item [69]  E
+    \item [70]  F
+    \item [71]  G
+    \item [72]  H
+    \item [73]  I
+    \item [74]  J
+    \item [75]  K
+    \item [76]  L
+    \item [77]  M
+    \item [78]  N
+    \item [79]  O
+    \item [80]  P
+    \item [81]  Q
+    \item [82]  R
+    \item [83]  S
+    \item [84]  T
+    \item [85]  U
+    \item [86]  V
+    \item [87]  W
+    \item [88]  X
+    \item [89]  Y
+    \item [90]  Z
+    \item [91]  [
+    \item [92]  \pounds
+    \item [93]  ]
+    \item [94]  $\uparrow$
+    \item [95]  $\leftarrow$
+    \item [96]  \graphicsymbol{C}
+    \item [97]  \graphicsymbol{A}
+    \item [98]  \graphicsymbol{B}
+    \item [99]  \graphicsymbol{C}
+    \item [100] \graphicsymbol{D}
+    \item [101] \graphicsymbol{E}
+    \item [102] \graphicsymbol{F}
+    \item [103] \graphicsymbol{G}
+    \item [104] \graphicsymbol{H}
+    \item [105] \graphicsymbol{I}
+    \item [106] \graphicsymbol{J}
+    \item [107] \graphicsymbol{K}
+    \item [108] \graphicsymbol{L}
+    \item [109] \graphicsymbol{M}
+    \item [110] \graphicsymbol{N}
+    \item [111] \graphicsymbol{O}
+    \item [112] \graphicsymbol{P}
+    \item [113] \graphicsymbol{Q}
+    \item [114] \graphicsymbol{R}
+    \item [115] \graphicsymbol{S}
+    \item [116] \graphicsymbol{T}
+    \item [117] \graphicsymbol{U}
+    \item [118] \graphicsymbol{V}
+    \item [119] \graphicsymbol{W}
+    \item [120] \graphicsymbol{X}
+    \item [121] \graphicsymbol{Y}
+    \item [122] \graphicsymbol{Z}
+    \item [123] \graphicsymbol{+}
+    \item [124] \graphicsymbol{-}
+    \item [125] \graphicsymbol{B}
+    \item [126] \graphicsymbol{\textbackslash}
+    \item [127] \graphicsymbol{]}
+    \item [128]
+    \item [129] \small{ORANGE}
+    \item [130] \small{UNDERLINE OFF}
+    \item [131]
+    \item [132]
+    \item [133] F1
+    \item [134] F3
+    \item [135] F5
+    \item [136] F7
+    \item [137] F2
+    \item [138] F4
+    \item [139] F6
+    \item [140] F8
+    \item [141] \specialkey{SHIFT}\megakey{RETURN}
+    \item [142] \small{UPPERCASE}
+    \item [143] \small{BLINK OFF}
+    \item [144] \small{BLACK}
+    \item [145] \megakey{$\uparrow$}
+    \item [146] \specialkey{RVS OFF}
+    \item [147] \specialkey{CLR HOME}
+    \item [148] \specialkey{INST DEL}
+    \item [149] \small{BROWN}
+    \item [150] \small{LT. RED}
+    \item [151] \small{DK. GRAY}
+    \item [152] \small{GRAY}
+    \item [153] \small{LT. GREEN}
+    \item [154] \small{LT. BLUE}
+    \item [155] \small{LT. GRAY}
+    \item [156] \small{PURPLE}
+    \item [157] \megakey{$\leftarrow$}
+    \item [158] \small{YELLOW}
+    \item [159] \small{CYAN}
+    \item [160] \megakey{SPACE}
+    \item [161] \graphicsymbol{k}
+    \item [162] \graphicsymbol{i}
+    \item [163] \graphicsymbol{t}
+    \item [164] \graphicsymbol{[}
+    \item [165] \graphicsymbol{g}
+    \item [166] \graphicsymbol{=}
+    \item [167] \graphicsymbol{m}
+    \item [168] \graphicsymbol{/}
+    \item [169] \graphicsymbol{?}
+    \item [170] \graphicsymbol{v}
+    \item [171] \graphicsymbol{q}
+    \item [172] \graphicsymbol{d}
+    \item [173] \graphicsymbol{z}
+    \item [174] \graphicsymbol{s}
+    \item [175] \graphicsymbol{n}
+    \item [176] \graphicsymbol{a}
+    \item [177] \graphicsymbol{e}
+    \item [178] \graphicsymbol{r}
+    \item [179] \graphicsymbol{w}
+    \item [180] \graphicsymbol{h}
+    \item [181] \graphicsymbol{j}
+    \item [182] \graphicsymbol{l}
+    \item [183] \graphicsymbol{y}
+    \item [184] \graphicsymbol{u}
+    \item [185] \graphicsymbol{p}
+    \item [186] \graphicsymbol{\{}
+    \item [187] \graphicsymbol{f}
+    \item [188] \graphicsymbol{c}
+    \item [189] \graphicsymbol{x}
+    \item [190] \graphicsymbol{v}
+    \item [191] \graphicsymbol{b}
+\end{description}
+\end{multicols}
+NOTE: Codes for 192 to 223 are the equal to 96-127. Codes 224 to 254 equal to 160-190 and code 255 equal to 126.
 \newpage
 
 


### PR DESCRIPTION
A few CHR$ codes were missing in the table. This PR adds them and switches to a multicols layout for better maintainability of the table in the latex sources.