### PR TITLE
Update assembler section

### DIFF
--- a/assemblers.tex
+++ b/assemblers.tex
@@ -1,17 +1,17 @@
 \chapter{Assemblers}
 
 The table below shows an overview of assemblers known to work with MEGA65.
-For general use we recommend \bf{ACME} as it has good support
+For general use we recommend {\bf ACME} as it has good support
 for the 45GS02 instruction set; is open source; and finally written in C. The latter
 means that it may be ported to run natively on the MEGA65 in the future. 
 
 \begin{longtable}{ l | l | l | l}\hline
 Compiler & 45GS02 support & Written in & Reference \\\hline
-ACME     &  yes                     & C          & \url{https://sourceforge.net/projects/acme-crossass}\\
-KickAss   &  yes                     & Java      & \\
-Ophis      &   yes                     & Python  & \url{https://github.com/michaelcmartin/Ophis}\\
-BSA        &  yes                      & C           & \url{https://github.com/Edilbert/BSA}\\
-CA65      &  no\footnote{Our fork CA65 correctly detects the MEGA65's CPU, but has no explicit support for the processor's features} & C & \url{https://github.com/mega65/cc65}\\\hline
+ACME     &  yes           & C          & \url{https://sourceforge.net/projects/acme-crossass}\\
+KickAss  &  yes           & Java       & \\
+Ophis    &  yes           & Python     & \url{https://github.com/michaelcmartin/Ophis}\\
+BSA      &  yes           & C          & \url{https://github.com/Edilbert/BSA}\\
+CA65     &  no\footnote{Our fork of CA65 (part of CC65) correctly detects the MEGA65's CPU, but has no explicit support for the processor's features} & C & \url{https://github.com/mega65/cc65}\\\hline
 \end{longtable}
 
 The {\bf BSA} assembler is currently used to build the {\bf MEGA65.ROM}.

--- a/assemblers.tex
+++ b/assemblers.tex
@@ -1,40 +1,21 @@
 \chapter{Assemblers}
 
-The short answer is that we recommend that you use the ACME
-assembler.  The mnemonics used by ACME are now considered the official
-onces for the 45GS02.  KickAsm is also quite suitable. The long answer continues below.
+The table below shows an overview of assemblers known to work with MEGA65.
+For general use we recommend \bf{ACME} as it has good support
+for the 45GS02 instruction set; is open source; and finally written in C. The latter
+means that it may be ported to run natively on the MEGA65 in the future. 
 
-There are any number of assemblers that can be used to develop for the
-MEGA65.  However only very few support the MEGA65's advanced CPU
-features, or even the C65 4510 instructions.
+\begin{longtable}{ l | l | l | l}\hline
+Compiler & 45GS02 support & Written in & Reference \\\hline
+ACME     &  yes                     & C          & \url{https://sourceforge.net/projects/acme-crossass}\\
+KickAss   &  yes                     & Java      & \\
+Ophis      &   yes                     & Python  & \url{https://github.com/michaelcmartin/Ophis}\\
+BSA        &  yes                      & C           & \url{https://github.com/Edilbert/BSA}\\
+CA65      &  no\footnote{Our fork CA65 correctly detects the MEGA65's CPU, but has no explicit support for the processor's features} & C & \url{https://github.com/mega65/cc65}\\\hline
+\end{longtable}
 
-Four different
-assemblers have been used for different parts of the MEGA65 software,
-reflecting the rather haphazard history of developing assembler
-support for the MEGA65.  The first assembler to support the MEGA65 was
-{\bf Ophis}, as it seemed the easiest to patch.  {\bf KickAss} later gained
-support, followed by ACME. {\bf ACME} added support at a convenient time, when
-the extended instructions, their names and syntax had sufficiently stabilised.
-
-From the perspective of the MEGA65 team, ACME has two advantages over KickAsm:
-First, it is open source, which fits the ethos of the project, and ensures long-term
-availability. Second, it is written in C, rather than Java, which means that
-it may be possible to port to run natively on the MEGA65 at some point in
-the future.
-
-Our fork of {\bf CA65} (\url{https://github.com/mega65/cc65}), the assembler
-used in CC65, also now has the ability
-to detect the MEGA65's CPU, but has no explicit support for the
-processor's features.  This is an important fix, however, as otherwise
-software using the CC65 processor detection routine thinks that the
-MEGA65 has a 65816, which can result in the execution of incompatible
-instructions. This causes problems with Synthmark64 0.2, for example.
-
-Bit Shifter's Assembler {\bf BSA} also supports the 45GS02.  The source
-for this assembler can be found at \url{https://github.com/Edilbert/BSA}.
-
-The {\bf BSA} Assembler is currently used for the assembly of the source code
-of the {\bf MEGA65.ROM}. Most of this source code is written in the syntax
+The {\bf BSA} assembler is currently used to build the {\bf MEGA65.ROM}.
+Most of this source code is written in the syntax
 of the ancient {\bf BSO} assembler (Boston Systems Office), which was used in the
 years 1989 - 1991 by software developers, working on the C65.
 The {\bf BSA} Assembler has a compatibility mode, which makes it
@@ -42,6 +23,6 @@ possible to assemble these old source codes with minor or none modifications.
 The {\bf BSA} Assembler has currently only a description of commands
 embedded in the C-source of the assembler.
 
-Therefore a chapter, describing the usage and the features of {\bf BSA}
-is started after this chapter and will be completed during the next weeks.
+%Therefore a chapter, describing the usage and the features of {\bf BSA}
+%is started after this chapter and will be completed during the next weeks.
 


### PR DESCRIPTION
This is an update to the assembler page where I tried to simplify and make the writing style slightly more towards what I would expect in a manual /  book. Things to check:

- [ ] Does it compile?
- [ ] Is the table layout ok?

I have unfortunately been unable to compile as I cannot create a working LaTeX setup. This is due to the dependency on `mega65-tools` which does not compile on macOS (due to hardcoded Makefiles) and not on my linux either (due to errors with windows cross compilation; can this be disabled?). I suspect these issues could present some barrier for contributing and I have thought of re-writing the build-system to `CMake` (of `mega65-tools`). Before going in that direction, I would like to hear if this has any interest? (ping @gardners).