### PR TITLE
corrects BSAVE syntax

### DIFF
--- a/appendix-basic10-condensed.tex
+++ b/appendix-basic10-condensed.tex
@@ -725,7 +725,7 @@ BOOT
 \index{BASIC 65 Commands!BSAVE}
 \begin{description}[leftmargin=2cm,style=nextline]
 \item [Token:] \$FE \$10
-\item [Format:] {\bf BSAVE filename ,P start TO end
+\item [Format:] {\bf BSAVE filename ,P start TO P end
                 [,B bank] [,D drive] [,U unit] }
 \item [Usage:]
    "Binary SAVE" saves a memory range to
@@ -759,10 +759,10 @@ BOOT
 \begin{tcolorbox}[colback=black,coltext=white]
 \verbatimfont{\codefont}
 \begin{verbatim}
-BSAVE "ML DATA", P 32768 TO 33792, B0, U9
-BSAVE "SPRITES", P 1536 TO 2058
-BSAVE "ML ROUTINES", B1, P(DEC("9000")) TO (DEC("A000"))
-BSAVE (FN$), B(BA%), P(PA) TO (PE), U(UN%)
+BSAVE "ML DATA", P32768 TO P33792, B0, U9
+BSAVE "SPRITES", P1536 TO P2058
+BSAVE "ML ROUTINES", B1, P(DEC("9000")) TO P(DEC("A000"))
+BSAVE (FN$), B(BA%), P(PA) TO P(PE), U(UN%)
 \end{verbatim}
 \end{tcolorbox}
 \end{description}


### PR DESCRIPTION
BSAVE syntax was slightly off. The "P" is needed before each part of the address. 