### PR TITLE
Replaced programme with program

### DIFF
--- a/appendix-45gs02-registers.tex
+++ b/appendix-45gs02-registers.tex
@@ -550,7 +550,7 @@ and Z registers with the immediate value, and then use \stw{ADCQ} with the memor
 
 Again, if you are using the ACME or another 45GS02-aware assembler, this can be more compactly and
 clearly written as follows. But note that in both cases the same byte-sequence of machine code is
-produced, and the programme will take the same number of cycles to execute.
+produced, and the program will take the same number of cycles to execute.
 
 \begin{tcolorbox}[colback=black,coltext=white]
 \verbatimfont{\codefont}
@@ -637,7 +637,7 @@ The 45GS02 handles all of these in a similar manner internally:
 \item The SYSCALL or trap address is calculated, based on the event.
 \item The contents of all CPU registers are saved into the virtualisation control registers.
 \item The hypervisor mode memory layout is activated, the CPU decimal flag and special purpose registers are all set to appropriate values.  The contents of the A,X,Y and Z and most other CPU flags are preserved, so that they can be accessed from the Hypervisor's SYSCALL/trap handler routine, without having to load them, thus saving a few cycles for each call.
-\item The hypervisor-mode flag is asserted, and the programme counter (PC) register is set to the computed address.
+\item The hypervisor-mode flag is asserted, and the program counter (PC) register is set to the computed address.
 \end{enumerate}
 
 All of the above happens in one CPU cycle, i.e., in 25 nano-seconds.

--- a/appendix-45io27-registers.tex
+++ b/appendix-45io27-registers.tex
@@ -83,7 +83,7 @@ and the full 4KiB buffer will be visible.
 
 The memory-mapped sector buffer has the advantage that it can be
 accessed via DMA, allowing for very efficient copies.  Also, it allows
-for loading a sector to occur in the background, while your programme
+for loading a sector to occur in the background, while your program
 gets on with more interesting things in the meantime.
 
 \subsection{Reading Sectors from a Disk}
@@ -238,7 +238,7 @@ formatting again.
 To successfully format a track, the user must provide the full structure
 of the track, including all sync marks, sector headers, CRC bytes, data regions and gaps.
 The explanation of this is beyond the scope of this document. The C65 Specifications Manual,
-the C65 ROM DOS source code and the {\tt floppytest.c} programme from the
+the C65 ROM DOS source code and the {\tt floppytest.c} program from the
 {\url https://github.com/mega65/mega65-tools} repository each describe and/or implement the
 process for formatting tracks.
 
@@ -268,7 +268,7 @@ during the write operation, you must add \$01 to the command code.
 However, this is not recommended on the MEGA65, because when writing
 to the SD card or using virtualised disk images the entire sector
 operation can happen instantaneously from the perspective of your
-programme.  This means that it is not possible to supply data reliably
+program.  This means that it is not possible to supply data reliably
 when in this mode.  Thus apart from being less convenient, it is also
 less reliable. 
 
@@ -304,12 +304,12 @@ This means that it
 would be possible to, for example, use standard 500KHz DD encoding for
 the directory track and one data track, and then switch to HD encoding for the other 79
 tracks of a disk. The result would be a disk that could contain a
-boot-loader programme and directory that can be read in a 1581, and
+boot-loader program and directory that can be read in a 1581, and
 that could be used to switch to the faster and higher-density HD
 encoding for the remaining data tracks.  This could even be done for
 half of a disk, so that when used in a 1581, it loads at the DD speed,
 but when inserted in a MEGA65, it uses the HD data tracks, allowing
-the programme to load twice as fast, and fit twice as much data.
+the program to load twice as fast, and fit twice as much data.
 
 You are really only limited by your imagination, available time, and
 the limited number of people who are still interested in inserting a
@@ -386,22 +386,22 @@ access to disk images resident on the SD card:
 \subsection{F011 Virtualisation}
 
 In addition to allowing automatic read and write access to SD-card
-based D81 images, it is possible to connect a programme to the serial
+based D81 images, it is possible to connect a program to the serial
 monitor interface that provides and accepts data as though it were the
 floppy disk.
 
 This is commonly used in a cross-development
 environment, where you wish to frequently modify a disk image that is
-used by a programme you are developing -- without the need to
+used by a program you are developing -- without the need to
 continually push new versions of the disk image on the MEGA65's
 SD-Card first. It also has the added benefit that it allows you to
 easily visualise which sectors are being read from and written to,
-which can help speed up development and debugging of your programme.
+which can help speed up development and debugging of your program.
 
 This function operates together with the MEGA65's Hypervisor by
 triggering hyperrupts (that is, interrupts that activate the
 Hypervisor).  There is then special code in the Hypervisor that
-communicates with the {\tt m65} programme via the serial monitor
+communicates with the {\tt m65} program via the serial monitor
 interface.
 
 If that all sounds rather complex, all you need to know is that to use

--- a/appendix-dmagic.tex
+++ b/appendix-dmagic.tex
@@ -41,16 +41,16 @@ and then write the address of this list into the DMA address registers.  The DMA
 the ADDRLSBTRIG register (\$D700).  For this reason you must write the MSB and bank number of the DMA list inti \$D701 and \$D702 first,
 and the LSB only after having set these other two registers.  If you wish to execute multiple DMA jobs using the same
 list structure in memory, you can simply write to ADDRLSBTRIG again after updating the list contents -- provided that
-no other programme has modified the contents of \$D701 or \$D702.  Note that BASIC 65 uses the DMA controller to
+no other program has modified the contents of \$D701 or \$D702.  Note that BASIC 65 uses the DMA controller to
 scroll the screen, so it is usually safest to always write to all three registers.
 
 When ADDRLSBTRIG has been written to, the DMA job completes immediately.  Unlike on the C65, the DMA controller is part
 of the processor of the MEGA65. This means that the processor stops trying to execute instructions {\em or fetching audio samples for DMA audio playback} until the DMA job
-has completed.  It also means that, unlike on the C65, DMA jobs cannot be interrupted. If your programme has sensitive timing
+has completed.  It also means that, unlike on the C65, DMA jobs cannot be interrupted. If your program has sensitive timing
 requirements, you may need to break larger DMA jobs into several smaller jobs.  This is somewhat mitigated by the high
 speed of the MEGA65's DMA, which is able to fill memory at 40.5MiB per second and copy memory at 20.25MiB per second, compared
 with circa 3.5 MiB and 1.7 MiB per second on a C65. This allows larger DMA jobs to be executed, without needing to worry about
-the impact on real-time elements of a programme. For example, it is possible to fill an 80 column 50 row text screen using the
+the impact on real-time elements of a program. For example, it is possible to fill an 80 column 50 row text screen using the
 MEGA65's DMA controller in just 200 microseconds.
 
 \subsection{F018 DMA Job List Format}
@@ -299,12 +299,12 @@ that uses a linear memory layout -- at the cost of consuming all of the processo
 during the active part of the display.
 
 The following example does this to draw vertical raster bars on the screen.
-This programme assumes that the MEGA65 is set to PAL.  For NTSC, the size of the DMA transfer
-would need to be decreased a little.  The other thing to note with this programme, is that
+This program assumes that the MEGA65 is set to PAL.  For NTSC, the size of the DMA transfer
+would need to be decreased a little.  The other thing to note with this program, is that
 it uses MEGA65 Enhanced DMA Job option \$81 to set the destination mega-byte in memory to
 \$FFxxxxx, and the bank is set to \$D, and the destination address to \$0021, to form the
 complete address \$FFD0021.  This is the true location of the VIC-IV's border colour register.
-The programme is written using ACME-compatible syntax.
+The program is written using ACME-compatible syntax.
 
 \begin{tcolorbox}[colback=black,coltext=white]
 \verbatimfont{\codefont}

--- a/appendix-donors.tex
+++ b/appendix-donors.tex
@@ -46,6 +46,10 @@ Business Advisor                   & MegaWAT Presentation Software \\
                                    & \textit{(Maurice)}  \\
 MEGAphone PCB Design               & BASIC-65 example programs \\
 & \\
+{\large\bf Daren Klamer}           \\
+ \textit{(Impakt)}                 \\
+Manual proof-reading               \\
+& \\
 \end{tabular}
 
 \newpage

--- a/appendix-instructionset.tex
+++ b/appendix-instructionset.tex
@@ -373,7 +373,7 @@ high-level language.  It is encoded identically to the Base Page Mode.
 \subsection{Relative Addressing Mode}
 
 In this addressing mode, the operand is an 8-bit signed offset to the
-current value of the Programme Counter (PC). It is used to allow branches
+current value of the Program Counter (PC). It is used to allow branches
 to encode the near-by address at which execution should proceed if the
 branch is taken.
 

--- a/appendix-keyboard.tex
+++ b/appendix-keyboard.tex
@@ -193,7 +193,7 @@ selected LED.
 
 To return the keyboard LEDs to hardware control, clear bit 7 of \$D61D.
 
-For example to pulse the keyboard LEDs red and blue, the following programme
+For example to pulse the keyboard LEDs red and blue, the following program
 could be used:
 
 \begin{tcolorbox}[colback=black,coltext=white]

--- a/appendix-memorymap.tex
+++ b/appendix-memorymap.tex
@@ -95,7 +95,7 @@ of RAM.
 
 On all models it is possible to use all or part of the 128KiB of ``ROM'' space as RAM. To do this, you must first
 request that the Hypervisor removes the read-only protection on this area, before you will be able to change
-its contents.  If you are writing a programme which will start from C64 mode, or otherwise switch to using the C64
+its contents.  If you are writing a program which will start from C64 mode, or otherwise switch to using the C64
 part of the ROM, instead of the C65 part), then the second half of that space, i.e., BANK 3, can be safely used
 for your programmes. This gives a total of 192KiB of RAM, which is available on all models of the MEGA65.
 
@@ -412,7 +412,7 @@ The MEGA65 is different: It uses 128KB of its 384KB fast chip RAM at
 hold these system programmes. This makes it possible to change or upgrade the
 ``ROM'' that the MEGA65 is running, without having to open the
 computer. It is even possible to use the MEGA65's Freeze Menu to
-change the ``ROM'' being used while a programme is running.
+change the ``ROM'' being used while a program is running.
 
 The C64 and C65 memory banking methods use this 128KB of area when
 making ROM banks visible.  When the RAM banks are mapped, they are
@@ -421,7 +421,7 @@ access that address area, it is possible to write to it. For improved
 backward compatibility, the whole 128KB region of memory is normally
 set to read-only.
 
-A programme can, however, request read-write access to this
+A program can, however, request read-write access to this
 128KB area of memory, so that it can make full use of the MEGA65's
 384KB of chip RAM.  This is accomplished by triggering the {\em Toggle
   Rom Write-protect} system trap of the hypervisor.  The following
@@ -445,7 +445,7 @@ state can be tested by attempting to write to this area of memory.
 Also, you can examine and toggle the current state from in the MEGA65
 Freeze Menu.
 
-NOTE: If you are starting your programme from C65 mode, you must first make
+NOTE: If you are starting your program from C65 mode, you must first make
 sure that the IO area is visible at \$D000-\$DFFF.  The simplest way to do
 this is to use the {\tt MAP} instruction with all zero values in the registers.
 The following fragment demonstrates this, and also makes sure that the MEGA65 IO

--- a/appendix-monitor.tex
+++ b/appendix-monitor.tex
@@ -422,20 +422,20 @@ FONT C : $02D000 : original C64 font
 
 This monitor is different to the other two: It is part of the MEGA65
 system itself, and runs concurrently with MEGA65's processor. That is,
-you can view and modify the memory the MEGA65, {\em while a programme is running}.
+you can view and modify the memory the MEGA65, {\em while a program is running}.
 
 This works using dedicated hardware in the MEGA65 design, that implements a little
 helper processor that runs this monitor interface, and has a special access mechanism
 to the memory and processor of the MEGA65.
 
 In comparison with the ROM-based monitors that execute on the MEGA65's primary processor,
-the matrix mode monitor has several advantages and disadvantes:
+the matrix mode monitor has several advantages and disadvantages:
 \begin{itemize}
-\item It can be used while a programme is running.
-\item It can be used, even if the ROM area is being used for programme code or data,
+\item It can be used while a program is running.
+\item It can be used, even if the ROM area is being used for program code or data,
   instead of containing a standard C65 or MEGA65 ROM.
 \item It can be accessed via the serial debug interface, via the JB1 connector.
-\item It can be instructed to stop the processor as soon as the programme counter (PC)
+\item It can be instructed to stop the processor as soon as the program counter (PC)
   register of the main processor reaches a user specified address. That is, it supports
   a (single) hardware breakpoint.
 \item It can be instructed to stop the processor whenever a specified memory address
@@ -489,7 +489,7 @@ Z & CPUHISTORY & CPU history \\
 To enter or exit the monitor hold down the \megasymbolkey and press the \specialkey{TAB} key.
 You will see an animation of green characters raining down from the top of the screen, and
 then be presented with a simple text terminal interface which is transparent, so that you can
-see the screen output of your running programme at the same time.
+see the screen output of your running program at the same time.
 
 \subsubsection{\# : Hypervisor trap enable/disable}
 
@@ -583,7 +583,7 @@ see the screen output of your running programme at the same time.
   then the breakpoint will be disabled. Otherwise the breakpoint is set to the
   provided 16-bit address.
 
-  Whenever the programme counter (PC) register of the MEGA65's processor equals the value
+  Whenever the program counter (PC) register of the MEGA65's processor equals the value
   provided to this command, the processor will halt, and the Matrix Mode monitor interface
   will display the last instruction executed and current register values to alert the user
   to this event. It does not activate the Matrix Mode display when this occurs. It is
@@ -652,11 +652,11 @@ see the screen output of your running programme at the same time.
 \index{MONITOR Commands!SETPC}
 \begin{description}[leftmargin=2cm,style=nextline]
 \item [Format:] {\bf g address}
-\item [Usage:] Sets the Programme Counter (PC) register of the MEGA65's processor
+\item [Usage:] Sets the Program Counter (PC) register of the MEGA65's processor
   to the supplied 16-bit address.  If the processor is running at the time, execution
   will immediately proceed from that address. If the processor is halted at the time,
   e.g., due to the use of the {\\tt t1} command, the processor remains halted, but with
-  the Programme Counter set to the indicated address, ready for when the processor is
+  the Program Counter set to the indicated address, ready for when the processor is
   again allowed to run.
 
 \end{description}
@@ -669,7 +669,7 @@ see the screen output of your running programme at the same time.
 \item [Format:] {\bf i[0|1]}
 \item [Usage:] Enables or disables interrupts on the MEGA65's
   processor. Disabling interrupts can be helpful when single-stepping
-  through a programme, as otherwise you will tend to end up only
+  through a program, as otherwise you will tend to end up only
   stepping through the interrupt handler code, because the interrupts
   will happen more frequently than the steps through the code.
 

--- a/appendix-target-specific.tex
+++ b/appendix-target-specific.tex
@@ -3,7 +3,7 @@
 \section{Detecting MEGA65 Models}
 
 While we expect the production version of the MEGA65 to be a stable platform, there may still be
-cases where detecting which hardware your programme is running on. This is particularly important
+cases where detecting which hardware your program is running on. This is particularly important
 for the MEGA65 system software, which may need to initialise different pieces of hardware on the
 different models.  Also, because there is a hand-held version of the MEGA65 already  in development,
 which uses a slightly different resolution screen (800x480 instead of 720x576), and has a touch
@@ -11,7 +11,7 @@ screen but no hardware keyboard, you may wish to make programmes that adapt to t
 devices in a more graceful way. For example, you may enable touch-screen input, and restructure
 on-screen selections to be large enough to be easily activated by a finger.
 
-The simple way to detect which model of MEGA65 your programme is running on, is to check the
+The simple way to detect which model of MEGA65 your program is running on, is to check the
 \$D629 register (but don't forget to enable the MEGA65 IO personality first, via \$D02F).
 This contains an 8-bit hardware identifier.  The following values are currently defined:
 

--- a/appendix-viciv-registers.tex
+++ b/appendix-viciv-registers.tex
@@ -88,13 +88,13 @@ Because the new features of the VIC-IV are all extensions to the existing VIC-II
 90 GOTO 40
 \end{screenoutput}
 
-Line 10 of this programme checks whether the screen is a multiple of 2KiB.
+Line 10 of this program checks whether the screen is a multiple of 2KiB.
 As the screen on the C64 is located at 1KiB, this test will fail, and execution
 will continue to line 20.  Line 20 writes 1 to one of the VIC-II sprite position
 registers, 53248, before writing the MEGA65 knock to the key register, 53295.
 Line 30 writes to 53248 + 256, which on the C64 is a mirror of 53248, but on a
 MEGA65 with VIC-IV IO enabled will be one of the red palette registers.
-After writing to 53248 + 256, the programme checks if the register at 53248 has
+After writing to 53248 + 256, the program checks if the register at 53248 has
 been modified by the write to 53248 + 256.  If it has, then the two addresses
 point to the same register.  This will happen on either a C64 or C65, but not on
 a computer with a VIC-IV.  Thus if 53248 has not changed, we report that we have detected a VIC-IV.

--- a/beginninginbasic.tex
+++ b/beginninginbasic.tex
@@ -40,7 +40,7 @@ report problems with this guide at:
 
 \url{https://github.com/mega65/mega65-user-guide}
 
-We hope you have as much fun learning to programme the MEGA65 as
+We hope you have as much fun learning to program the MEGA65 as
 we have had making it!
 
 \section{Your first BASIC programmes}
@@ -78,7 +78,7 @@ or \specialkey{CAPS\\LOCK} key down.  When you have typed ``HELLO COMPUTER'' pre
   You have succeeded in communicating with the computer!\index{Errors!Syntax}\index{SYNTAX ERROR}
   Error messages sound much nastier than they are.  The MEGA65 uses them, especially
   the syntax error to tell you when it is having trouble understanding what you have
-  typed, or what you have put in a programme.  They are nothing to be afraid of, and
+  typed, or what you have put in a program.  They are nothing to be afraid of, and
   experienced programmers get them all the time.
 
   In this case, the computer was confused because it doesn't understand the word
@@ -157,7 +157,7 @@ Hopefully now you will see something like the following:
 
 \needspace{4cm} % Dont allow following paragraph to separate from
                 % following screenshot
-  Let's try that out with a simple little programme.  Type in the following three lines of
+  Let's try that out with a simple little program.  Type in the following three lines of
   input:
 
 \begin{screenoutput}
@@ -185,9 +185,9 @@ We have told the computer to remember three commands, that is, \screentextwide{F
 and \screentextwide{NEXT I}.  We have also told the computer which order we would like to run them in: The
 computer will start with the command with the lowest number, and execute each command that
 has the next higher number in turn, until it reaches the end of the list.  So it's a bit like
-a reminder list for the computer. This is what we call a programme, a bit like the programme at
+a reminder list for the computer. This is what we call a program, a bit like the program at
 a concert or the theatre, it tells us what is coming up, and in what order.
-So let's tell the computer to execute this programme.
+So let's tell the computer to execute this program.
 
 But first, let's try to guess what will happen.  Let's start with the middle command, \screentextwide{PRINT I}.
 We've seen the \screentextwide{PRINT} command, and we know it tells the computer to print things to the screen.
@@ -202,7 +202,7 @@ with the variable called I with another piece of information.  The old piece wil
 as a result.  So if we gave a command like \screentextwide{LET I = 3}, this would replace whatever was stored
 in the variable called \screentextwide{I} with the number 3.
 
-Back to our programme, we now know that the 2\textsuperscript{nd} command will try to print the piece of information
+Back to our program, we now know that the 2\textsuperscript{nd} command will try to print the piece of information
 stored in the variable \screentextwide{I}.  So lets look at the first command: \screentextwide{FOR I = 1 TO 10 STEP 1}.  Although
 we haven't seen the \screentextwide{FOR} command before, we can take a bit of a guess at how it works. It looks like
 it is going to put something into the variable \screentextwide{I}.  That something seems to have something to do
@@ -231,8 +231,8 @@ indicated it to do.
 
 \needspace{4cm} % Dont allow following paragraph to separate from
                 % following screenshot
-To see this in action, we need to tell the computer to execute the programme of commands we typed in.
-We do this by using the \screentextwide{RUN} command. Because we want it to run the programme immediately, we
+To see this in action, we need to tell the computer to execute the program of commands we typed in.
+We do this by using the \screentextwide{RUN} command. Because we want it to run the program immediately, we
 should use immediate mode (remember, this is another name for direct mode).
 So just type in the word \screentextwide{RUN} and press the \specialkey{RETURN} key.  You should then see a display
 that looks something like the following:
@@ -242,30 +242,30 @@ that looks something like the following:
   You might notice a couple of things here:
 
   First, the computer has told us it is \screentextwide{READY.} again
-  as soon as it finished running the programme. This just makes it easier for us to know when we
+  as soon as it finished running the program. This just makes it easier for us to know when we
   can start giving commands to the computer again.
 
   Second, when the computer got to the bottom of the screen
   it automatically scrolled the display up to make space.  This is quite normal.  What is important
   to remember, is that the computer forgets everything that scrolls off the top.  The only exception
   is if you have told the computer to remember a command by putting a number in front of it.  So
-  our programme is quite safe for now. We can see that this is the case by typing the \screentextwide{RUN} command a
-  couple more times: The programme listing will have scrolled off the top of the screen, but we can
-  still RUN the programme, because the computer has remembered it.  Give it a try!
+  our program is quite safe for now. We can see that this is the case by typing the \screentextwide{RUN} command a
+  couple more times: The program listing will have scrolled off the top of the screen, but we can
+  still RUN the program, because the computer has remembered it.  Give it a try!
   Did it work?
 
 \needspace{4cm} % Dont allow following paragraph to separate from
                 % following screenshot
-  If you wish to see the programme of remembered commands, you can use the \screentextwide{LIST}\index{LIST}\index{BASIC 65 Commands!LIST}
-  command.  This commands causes the computer to display the remembered programme of commands to the screen, like in the display here.
-  If you would like to replace any of the commands in the programme, you can type a new line that has the same number as the one you
+  If you wish to see the program of remembered commands, you can use the \screentextwide{LIST}\index{LIST}\index{BASIC 65 Commands!LIST}
+  command.  This commands causes the computer to display the remembered program of commands to the screen, like in the display here.
+  If you would like to replace any of the commands in the program, you can type a new line that has the same number as the one you
   wish to change.
 
 \screenshotwrap{images/getting-started/first-steps-for-loop-programme-1-listing.png}
 
 \needspace{4cm} % Dont allow following paragraph to separate from
                 % following screenshot
-  For example, to print the results all on one line, we could modify the second line of the programme to \screentextwide{PRINT I;} by
+  For example, to print the results all on one line, we could modify the second line of the program to \screentextwide{PRINT I;} by
   typing the following line of input and pressing the \specialkey{RETURN} key:
 
 
@@ -283,7 +283,7 @@ that looks something like the following:
 
 You can make sure that the change has been remembered by running the \screentextwide{LIST} command again, as we can see here.
 You can then use the \screentextwide{RUN} command to run the modified
-programme, like this:
+program, like this:
 
 \screenshotwrap{images/getting-started/first-steps-for-loop-programme-1-modified.png}
 
@@ -291,14 +291,14 @@ It is quite easy to modify your programmes in this way.  As you become more comf
 additional helpful tricks:
 
 First, you can give the \screentextwide{LIST} command the number of a command, or line as they are referred to, and it will display only
-that line of the programme.  Alternatively, you can give a range separated by a minus sign to display only a section of the programme,
-e.g., \screentextwide{LIST 1 - 2} to list the first two lines of our programme.
+that line of the program.  Alternatively, you can give a range separated by a minus sign to display only a section of the program,
+e.g., \screentextwide{LIST 1 - 2} to list the first two lines of our program.
 
 Second, you can use the cursor keys to move the cursor to a line which has already been remembered and is displayed on the screen. If you
 modify what you see on the screen, and then press the \specialkey{RETURN} key while the cursor is on that line, the BASIC interpreter will
-read in the modified line and replace the old version of it.  It is important to note that if you modify multiple lines of the programme
+read in the modified line and replace the old version of it.  It is important to note that if you modify multiple lines of the program
 at the same time, you must press the \specialkey{RETURN} key on each line that has been modified. It is good practice to check that the
-programme has been correctly modified. Use the \specialkey{LIST}\index{LIST}\index{BASIC 65 Commands!LIST} command again to achieve this.
+program has been correctly modified. Use the \specialkey{LIST}\index{LIST}\index{BASIC 65 Commands!LIST} command again to achieve this.
 
 
   \subsubsection{Exercises to try}
@@ -379,7 +379,7 @@ you want it to process what you typed.  From here on, we will assume that you ca
 
 \needspace{4cm} % Dont allow following paragraph to separate from
                 % following screenshot
-The \screentextwide{?} shortcut also works if you are telling the computer to remember a command as part of a programme.
+The \screentextwide{?} shortcut also works if you are telling the computer to remember a command as part of a program.
 So if you type \screentextwide{1 ? N}, and then \screentextwide{LIST}, you will see \screentextwide{1 PRINT N}, as we can see
 in the following screen-shot:
 
@@ -456,7 +456,7 @@ We'll talk about those a bit later on.)
 
 So far we have only given values to variables in direct mode, or
 by using constructions like \screentextwide{FOR} loops.  But we
-haven't seen how we can get information from the user when a programme
+haven't seen how we can get information from the user when a program
 is running.  One way that we can do this, is with the
 \screentextwide{INPUT}\index{BASIC 65 Commands!INPUT}\index{INPUT}
 command.
@@ -477,7 +477,7 @@ Try it, and you should see something like the following
 
 \needspace{4cm}
 This means that the \stw{INPUT} command can only be used as part of a
-programme.  So we can instead do something like the following:
+program.  So we can instead do something like the following:
 
 \begin{screenoutput}
 1 INPUT A$
@@ -495,9 +495,9 @@ what the \stw{INPUT} command read from the user.  Let's try it out:
 
 Did you expect that to happen? What is this question mark doing there?
 The \stw{?} here is the computer's way of telling you that a
-programme is waiting for some input from you.  This means that the
+program is waiting for some input from you.  This means that the
 computer uses the same symbol, \stw{?}, to mean two different things:
-If you type it as part of a programme or in direct mode, then it is a
+If you type it as part of a program or in direct mode, then it is a
 short-cut for the \stw{PRINT} command. That's when you type it. But if
 the computer shows it to you, it has this other meaning, that the
 computer is waiting for you to type something in. There is also a
@@ -511,12 +511,12 @@ different situations or contexts, we say that it its {\em context
 \needspace{4cm}
 But returning to our example,  if we now type
 something in, and press the \specialkey{RETURN} key to tell the
-computer that you are done, the programme will continue, like this:
+computer that you are done, the program will continue, like this:
 
 \screenshotwrap{images/getting-started/input-example-2}
 
 \needspace{4cm}
-Of course, we didn't really know what to type in, because the programme
+Of course, we didn't really know what to type in, because the program
 didn't give any hints to the user as to what the programmer wanted
 them to do. So we should try to provide some instructions.  For
 example, if we wanted the user to type their name, we could print a
@@ -529,13 +529,13 @@ message asking them to type their name, like this:
 \end{screenoutput}
 
 \needspace{4cm}
-Now if we run this programme, the user will get a clue as to what we
+Now if we run this program, the user will get a clue as to what we
 expect them to do, and the whole experience will make a lot more sense
 for them:
 
 \screenshotwrap{images/getting-started/input-example-3}
 
-When we run the programme, we first see the \stw{WHAT IS YOUR NAME} message
+When we run the program, we first see the \stw{WHAT IS YOUR NAME} message
 from line 1.  The computer doesn't print the double-quote symbols,
 because they only told the computer that the piece of information
 between them is a string.  The string itself is only the part in
@@ -546,27 +546,27 @@ telling us that the computer is waiting for some input from us.  The
 rest of the programmed is {\em blocked}\index{IO!blocking}\index{blocked} from continuing until it we type the
 piece of information.  Once we type the piece of input, the computer
 stores it into the variable \stw{A\$}, and can continue.  Thus when it
-reaches line 3 of the programme, it has everything it needs, and
+reaches line 3 of the program, it has everything it needs, and
 prints out both the \stw{HELLO} message, as well as the information
 stored in the variable called \stw{A\$}.
 
 Notice that the word \stw{LISTER} doesn't appear anywhere in the
-programme.  It exists only in the variable.  This ability to process
-information that is not part of a programme is one of the things that
+program.  It exists only in the variable.  This ability to process
+information that is not part of a program is one of the things that
 makes computer programmes so powerful and able to be used for so many
 purposes. All we have to do is to change the input, and we can get
 different output.
 
 
 \needspace{4cm}
-For example, with our programme we run it again and again, and give it
+For example, with our program we run it again and again, and give it
 different input each time, and the
-programme will adapt its output to what we type. Pretty nifty, right?
+program will adapt its output to what we type. Pretty nifty, right?
 Let's have the rest of the crew try it out:
 
 \screenshotwrap{images/getting-started/input-extra-ignored-1}
 
-We can see that each time the programme prints out the message
+We can see that each time the program prints out the message
 customised with the input that you typed in\ldots Until we get to
 \stw{RIMMER, BSC}. As always, Mr. Rimmer is causing trouble.  In this
 case, he couldn't resist putting his Bronze Swimming Certificate
@@ -577,7 +577,7 @@ given us a kind of error message, \stw{?EXTRA IGNORED}\index{Extra
   Ignored}\index{Errors!Extra Ignored}\index{Warnings!Extra Ignored}.
 The error is not written in red, and doesn't have the word \stw{ERROR}
 on the end.  This means that it is a warning, rather than an error.
-Because it is only a warning, the programme continues.  But something
+Because it is only a warning, the program continues.  But something
 has happened: The computer has ignored Mr. Rimmer's \stw{BSC}, that
 is, it has ignored the extra input.  This
 is because the \stw{INPUT} command doesn't really read a whole line
@@ -591,7 +591,7 @@ If you want to include one of those symbols, you need to surround the
 whole piece of information in double-quotes.  So, if Mr. Rimmer had
 read this guide instead of obsessing over the Space Core Directives,
 he would have known to type \stw{"RIMMER, BSC"} (complete with the
-double-quotes), to have the programme
+double-quotes), to have the program
   run correctly.  It is important that the quotes go around the whole
   piece of information, as otherwise the computer will think that the
   first quote marks the start of a new piece of information.  We can
@@ -605,7 +605,7 @@ While this can all be a bit annoying at times, it has a purpose: The
 information.  We do this by putting more than one variable after the
 \stw{INPUT} command, each separated by a comma.  The \stw{INPUT}
 command will then expect multiple pieces of information.  For example,
-we could ask for someone's name and age, with a programme like this:
+we could ask for someone's name and age, with a program like this:
 
 \begin{screenoutput}
   1 PRINT "WHAT IS YOUR NAME AND AGE"
@@ -615,7 +615,7 @@ we could ask for someone's name and age, with a programme like this:
 \end{screenoutput}
 
 \needspace{4cm}
-If we run this programme, we can provide the two pieces of information
+If we run this program, we can provide the two pieces of information
 on the one line when the computer presents us with the \stw{?} prompt,
 for example \stw{LISTER, 3000000}. Note the comma that separates the
 two pieces of information, \stw{LISTER} and \stw{3000000}.  It's also
@@ -623,14 +623,14 @@ worth noticing that we haven't put any thousands separators into the
 number 3,000,000.  If we did, the computer would think we meant three
 separate pieces of information, \stw{3}, \stw{000} and \stw{000},
 which is not what we meant.  So let's see what it looks like when we
-give \stw{LISTER, 3000000} as input to the programme:
+give \stw{LISTER, 3000000} as input to the program:
 
   \screenshotwrap{images/getting-started/input-multiple-1}
 
   In this case, the \stw{INPUT}\index{INPUT}
   \index{BASIC 65 Commands!INPUT} command reads the two pieces of
 information, and places the first into the variable \stw{A\$}, and the second
-into the variable \stw{A}. When the programme reaches line 3 it prints
+into the variable \stw{A}. When the program reaches line 3 it prints
 \stw{HELLO} followed by the first piece of information.
 Then when it gets to line 4, it prints the string \stw{YOU ARE},
 followed by the contents of the variable \stw{A}, which is the number
@@ -645,13 +645,13 @@ same \stw{??} prompt, rather than printing more and more
 question-marks.)
 
 \needspace{4cm}
-So if we try this with our programme, we can see this \stw{?} and
+So if we try this with our program, we can see this \stw{?} and
 \stw{??} prompts, and how the first piece of information ends up in
 \stw{A\$} because it is the first variable in the \stw{INPUT}
 command.
 The second piece of information ends up in \stw{A} because \stw{A} is
 the second variable after the \stw{INPUT} command. Here's how it
-looks if we give this input to our programme:
+looks if we give this input to our program:
 
 
 \screenshotwrap{images/getting-started/input-multiple-2}
@@ -662,11 +662,11 @@ command to tell the computer which variables we would like to have
 some information input into.  But, like with the \stw{PRINT} command,
 this is something that happens often enough, that there is a shortcut
 for it. It also has the advantage that it looks nicer when
-running, and makes the programme a little shorter. The short cut is to
+running, and makes the program a little shorter. The short cut is to
 put the message to show after the \stw{INPUT} command, but before the
 first variable.
 
-We can change our programme to use this approach.  First, we can
+We can change our program to use this approach.  First, we can
 change line 3 to include the prompt after the \stw{INPUT} command.  We
 can do this one of two ways: First, we could just type in a new line
 3. The computer will automatically replace the old line 3 with the new
@@ -684,7 +684,7 @@ of the line.\index{Programmes!editing}\index{Programmes!replacing
 Either way, you
 can check that the changes succeeded by typing the \stw{LIST} command
 on any line of the screen that is blank.  This will show the revised
-version of the programme.  For example:
+version of the program.  For example:
 
 \screenshotwrap{images/getting-started/replacing-line-1}
 
@@ -707,7 +707,7 @@ running the \stw{LIST} command again, like this:
 \screenshotwrap{images/getting-started/deleting-line-1}
 
 Did you notice something interesting? When we told the computer to
-make line 1 of the programme empty, it deleted it completely!
+make line 1 of the program empty, it deleted it completely!
 That's because the computer thinks that an empty line is of no use.
 It also makes sure that your programmes don't get all cluttered up
 with empty lines if you make lots of changes to your programmes.
@@ -721,7 +721,7 @@ It is also possible to DELETE a range of lines. For example (but don't do this n
 You can read more about the DELETE command in the BASIC 65 Command Reference.
 
 \needspace{4cm}
-With that out the way, let's run our programme and see what happens.
+With that out the way, let's run our program and see what happens.
 As usual, just type in the \stw{RUN} command and hit the
 \specialkey{RETURN} key.  You should see something like this:
 
@@ -739,31 +739,31 @@ INPUT "WHAT IS YOU NAME AND AGE"; A$, A
 \end{screenoutput}
 
 \needspace{4cm}
-Now if we run the programme, we should see what we are looking for:
+Now if we run the program, we should see what we are looking for:
 
 \screenshotwrap{images/getting-started/input-semicolon}
 
   \subsubsection{Exercises to try}
 
-  {\bf 1. Can you make the programme ask someone for their name, and
+  {\bf 1. Can you make the program ask someone for their name, and
     then for their favourite colour?}
 
   At the moment it asks for their name and age. Can you change the
-  programme so that it reports on their favourite colour instead of
+  program so that it reports on their favourite colour instead of
   their age?
 
   {\em Clue:} What type of information is age? Is it numeric or a
   string? Is it the same type of information as the name of a colour?
 
-  {\bf 2. Can you write a programme that asks someone for their name,
+  {\bf 2. Can you write a program that asks someone for their name,
     prints the hello message, and then asks for their age and prints
     out that response?}
 
   \needspace{2cm}
-  At the moment, the programme expects both pieces of information at
-  the same time. This means the programme can't print a message about
+  At the moment, the program expects both pieces of information at
+  the same time. This means the program can't print a message about
   the first message until after it has both pieces of information.
-  Change the programme so that you can have an interaction like the
+  Change the program so that you can have an interaction like the
   following instead:
 
 \begin{screenoutput}
@@ -773,17 +773,17 @@ WHAT IS THE ANSWER? 42
 YOU SAID THE ANSWER IS 42
 \end{screenoutput}
 
-{\em Clue:} You will need more lines in your programme, so that you
+{\em Clue:} You will need more lines in your program, so that you
 can have more than one \stw{INPUT} and \stw{PRINT} command.
 
-{\bf 3. Can you write a programme that asks several questions, and
+{\bf 3. Can you write a program that asks several questions, and
   then prints out the list of answers given?}
 
 \needspace{2cm}
 Think of several questions you would like to be able to ask someone,
-and then write a programme that asks them, and remembers the answers
+and then write a program that asks them, and remembers the answers
 and prints them out with an appropriate message. For example, running
-your programme could look like this:
+your program could look like this:
 
 \begin{screenoutput}
   WHAT IS YOUR NAME? FRODO
@@ -795,7 +795,7 @@ your programme could look like this:
   YOU FAVOURITE FOOD IS EVERYTHING!
 \end{screenoutput}
 
-{\em Clue:} You will need more lines in you programme, to have the
+{\em Clue:} You will need more lines in you program, to have the
 various \stw{INPUT} and \stw{PRINT} commands.
 
 {\em Clue:} You will need to think carefully about which variable
@@ -894,13 +894,13 @@ should see something like the following:
 We can see that only the \stw{PRINT} commands that followed an
 \stw{IF} command that has a true value were executed. The rest
 were silently ignored by the computer.  But we can of course include
-these into a programme. So lets make a little programme that will ask
+these into a program. So lets make a little program that will ask
 for two numbers, and say whether they are equal, or if one is greater
-or less than the other.  Before you have a look at the programme, have
+or less than the other.  Before you have a look at the program, have
 a think about how you might do it, and see if you can figure it out.
 The clue I will give you, is that the \stw{IF} command also accepts the name of
 a variables, not just numbers. So you can do something like \stw{IF A
-  > B THEN PRINT "SOMETHING"}. The programme will be on the next page, to stop you peeking before you
+  > B THEN PRINT "SOMETHING"}. The program will be on the next page, to stop you peeking before you
 have a think about it!
 
 \pagebreak
@@ -916,13 +916,13 @@ but here is what I came up with:
 5 IF B > A THEN PRINT "THE SECOND NUMBER IS BIGGER"
 \end{screenoutput}
 
-We can then run the programme as often as we like, and the computer
+We can then run the program as often as we like, and the computer
 can tell us which of the two numbers we give it is biggest, or if they
 are equal:
 
 \screenshotwrap{images/getting-started/if-compare-variables-1}
 
-Notice how in this programme, we didn't use fixed numbers in the
+Notice how in this program, we didn't use fixed numbers in the
 \stw{IF} command, but instead gave variable names instead.  This is
 one of the very powerful things in computer programming, together
 with being able to make decision based on data. By being able to refer
@@ -941,11 +941,11 @@ can use \stw{LET} to set a variable to the secret number, \stw{INPUT}
 to prompt the user for their guess, and then \stw{IF}, \stw{THEN} and
 \stw{PRINT} to tell the user whether their guess was correct or not.
 So let's make something. Again, if you like, stop and think and
-experiment for a few minutes to see if you can make such a programme
+experiment for a few minutes to see if you can make such a program
 yourself.
 
 Here is how I have done it.  But don't worry if you have done it in a
-quite different way: There are often many ways to write a programme to
+quite different way: There are often many ways to write a program to
 perform a particular task.
 
 \begin{screenoutput}
@@ -993,7 +993,7 @@ NEXT I
 But there are better ways.  If you hold down the \specialkey{SHIFT}
 key, and then press the \specialkey{CLR\\HOME} key, it clears the
 screen.  This is much simpler and more convenient. But how can we do
-something like that in our programme?  It turns out to be very simple:
+something like that in our program?  It turns out to be very simple:
 You can type it while entering a string!  This is because the keyboard
 works differently based on whether you are in {\em quote
   mode}\index{quote mode}.
@@ -1030,13 +1030,13 @@ To do this, start by typing \stw{2 PRINT "}.  Then hold the
 Your line should now look like \stw{2 PRINT"Ƴ}.  If so, you have
 succeeded! You can now finish typing the line as normal.  When you
 have done that, you can use the \stw{LIST} command as usual, to make
-sure that you have successfully modified the programme.   You should
+sure that you have successfully modified the program.   You should
 see your modified line with the \stw{Ƴ} symbol in it.
 
 \screenshotwrap{images/getting-started/guess-number-2}
 
 \needspace{2cm}
-If you now run the programme by typing in \stw{RUN} and pressing the
+If you now run the program by typing in \stw{RUN} and pressing the
 \specialkey{RETURN} key as usual, the 2\textsuperscript{nd} line tells
 the compute to clear the screen before printing the rest of the message, like this:
 
@@ -1046,16 +1046,16 @@ This hides the listing from the user, so that they can't immediately see
 what our secret number is.  We can type our guess in, just like before,
 but just like before, after one guess, it returns to the \stw{READY.}
 prompt.  We really would like people to be able to make more than one
-guess, without needing to know that they need to run the programme
+guess, without needing to know that they need to run the program
 again.
 
 \needspace{3cm}
 There are a few ways we could do this. We already saw the \stw{FOR} --
-\stw{NEXT} pattern. With that, we could make the programme give the
+\stw{NEXT} pattern. With that, we could make the program give the
 user a certain number of guesses.  If we followed the \stw{NEXT}
-command with another programme line, we could even tell the user when
+command with another program line, we could even tell the user when
 they have taken too many guesses.  So lets have a look at our
-programme and see how we might do that.  Here is our current listing again:
+program and see how we might do that.  Here is our current listing again:
 
 \begin{screenoutput}
 1 SN=23
@@ -1077,10 +1077,10 @@ Fortunately, the MEGA65 has the
 \stw{RENUMBER}\index{RENUMBER}\index{BASIC 65 Commands!RENUMBER}
 \index{Lines!renumbering}
 command.  This command can be typed only in direct mode. When
-executed, it changes the line numbers in the programme, while keeping
+executed, it changes the line numbers in the program, while keeping
 them in the same order.  The new numbers are normally multiples of 10,
 so that you have lots of spare numbers in between to add extra lines.
-For example, if we use it on our programme, it will renumber the lines
+For example, if we use it on our program, it will renumber the lines
 to 10, 20, \ldots, 60. We can see that this has happened by using the
 \stw{LIST} command:
 
@@ -1122,8 +1122,8 @@ What will happen if they run out of guesses?
 If you worked out that making a guess that the screen will be
 immediately cleared, you can give yourself a pat on the back! The user
 will hardly have time to see the message. Worse, if they guess the
-number correctly, they won't know, and the programme will keep going.
-We'd really like the programme to stop or end, once the user makes a
+number correctly, they won't know, and the program will keep going.
+We'd really like the program to stop or end, once the user makes a
 correct guess.
 
 \index{STOP}\index{BASIC 65 Commands!STOP}
@@ -1131,12 +1131,12 @@ correct guess.
 \index{CONT}\index{BASIC 65 Commands!CONT}
 We can do this using either the \stw{STOP} or
 \stw{END} commands.  These two commands are quite similar.  The main
-difference is that if you \stw{STOP} a programme, the computer tells
+difference is that if you \stw{STOP} a program, the computer tells
 you where it has stopped, and you have the chance to continue the
-programme using the \stw{CONT} command.  The \stw{END} command, on the
-other hand, tells the computer that the programme has reached its end,
+program using the \stw{CONT} command.  The \stw{END} command, on the
+other hand, tells the computer that the program has reached its end,
 and it should go back to being \stw{READY}.  The \stw{END} command
-makes more sense for our programme, because after the user has guessed
+makes more sense for our program, because after the user has guessed
 the number, there isn't any reason to continue.
 
 Now we need a way to be able tell the computer to do two different
@@ -1152,7 +1152,7 @@ characters that separate pieces of information: \stw{,} and\index{, (comma)}
 \stw{:}\index{: (colon)}. The second one, \stw{:}, is called a colon, and can also be
 used to separate BASIC commands on a single line.  So if we want to
 change line 60 to \stw{PRINT} the message of congratulations and then
-\stw{END} the programme, we can just add \stw{: END} to the end of the
+\stw{END} the program, we can just add \stw{: END} to the end of the
 line. The line should look like this:\index{: (colon)}
 
 \begin{screenoutput}
@@ -1164,16 +1164,16 @@ screen after every guess, so that the user can see what their last
 guess was, and whether it was bigger or smaller than the number.  To
 do this, we can remove the clear-screen code from line 20, and add a
 new print command to a lower line number, so that it clears the screen
-once at the start of the programme, before the user gets to start
+once at the start of the program, before the user gets to start
 guessing.
 
 \needspace{2cm}
 For example, we could it put in line 5, so that it happens
-as the absolute first action of the programme.  As we mentioned
+as the absolute first action of the program.  As we mentioned
 earlier, the line numbers themselves aren't important: All that is
 important is to remember that the computer starts at the lowest line
 number, and runs the lines in order.  Anyway, let's make those changes
-to our programme:
+to our program:
 
 \begin{screenoutput}
   20 PRINT "GUESS THE NUMBER BETWEEN 1 AND 100"
@@ -1181,13 +1181,13 @@ to our programme:
 \end{screenoutput}
 
 \needspace{4cm}
-If you type those lines in, and \stw{LIST} the programme again, you
+If you type those lines in, and \stw{LIST} the program again, you
 should see something like the following:
 
 \screenshotwrap{images/getting-started/guess-number-5}
 
 \needspace{4cm}
-We can now \stw{RUN} the programme, and see whether it worked. Let's try it!
+We can now \stw{RUN} the program, and see whether it worked. Let's try it!
 
 \screenshotwrap{images/getting-started/guess-number-6}
 
@@ -1202,7 +1202,7 @@ done everything.  So if we change line 5 to \stw{5 PRINT "Ƴ";} this
 will make the empty space at the top the screen disappear.
 
 \needspace{4cm}
-But back to our programme, we can now make guesses, and the programme
+But back to our program, we can now make guesses, and the program
 will tell us whether each guess is more or less than the correct
 number.  And after 10 guesses, it stops asking for guesses, and goes
 back to the \stw{READY.} prompt, like this:
@@ -1214,7 +1214,7 @@ It would be nice to tell the user if they have run out of
 guesses. We need to add this message after the \stw{NEXT} command.
 We should also be nice and tell them what the secret number was,
 instead of leaving them wondering.
-So let's add the line to the end of our programme as line 80:
+So let's add the line to the end of our program as line 80:
 
 \begin{screenoutput}
 80 PRINT "SORRY! YOU RAN OUT OF GUESSES. MY NUMBER WAS"; SN
@@ -1228,9 +1228,9 @@ message, like this:
 
 \subsubsection{Exercises to try}
 
-{\bf 1. Can you make the programme ask at the start for the secret number?}
+{\bf 1. Can you make the program ask at the start for the secret number?}
 
-At the moment the programme sets the secret number to 23 every
+At the moment the program sets the secret number to 23 every
 time. To make the game more interesting it would be great to ask the
 first user for the secret number, and then start the rest of the game,
 so that someone else can try to guess the number.
@@ -1239,15 +1239,15 @@ so that someone else can try to guess the number.
 so that it can be read from the first user. You might find the
 \stw{INPUT} statement useful.
 
-{\bf 2. Can you make the programme ask for the user's name and give
+{\bf 2. Can you make the program ask for the user's name and give
   personalised responses?}
 
-At the moment, the programme displays very simple messages. It would
+At the moment, the program displays very simple messages. It would
 be nice to ask the user their name, and then use their name to produce
 personalised messages, like \stw{SORRY DAVE, BUT THAT NUMBER IS TOO
   SMALL}.
 
-{\em Clue: You will need to add a line early in the programme to ask
+{\em Clue: You will need to add a line early in the program to ask
   the user their name.}
 
 {\em Clue: You might like to review how we used the \stw{PRINT}
@@ -1255,7 +1255,7 @@ personalised messages, like \stw{SORRY DAVE, BUT THAT NUMBER IS TOO
 
 {\bf 3. Can you improve the appearance of the messages with colours and better spacing?}
 
-We haven't really made the programme particularly pretty.  It would be
+We haven't really made the program particularly pretty.  It would be
 great to use colours.
 
 {\em Clue: You might like to add more \stw{PRINT} commands to improve
@@ -1272,9 +1272,9 @@ text, screen background and border.
 \index{BORDER}\index{BASIC 65 Commands!BORDER}}
 
 
-{\bf 4. Can you make the programme say if a guess is ``warmer'' or ``colder'' than the previous guess?}
+{\bf 4. Can you make the program say if a guess is ``warmer'' or ``colder'' than the previous guess?}
 
-At the moment the programme just tells you if the guess is higher or
+At the moment the program just tells you if the guess is higher or
 lower than the secret number.  It would be great if it could tell you
 if a guess is getting closer or further away with each guess: When
 they get closer, it should tell the user that they are getting ``warmer'',
@@ -1294,7 +1294,7 @@ requires you to work out some new things.
 We'll come back to the Guess The Number game shortly, but let's take a
 detour first. Through a maze. Let's hope we can get back out before
 the end of the lesson!  Let's look at a simple way to make a
-maze. This programme has been known for a long time.  It works by
+maze. This program has been known for a long time.  It works by
 choosing at random whether to display a {\symbolfont{M}} or a
 {\symbolfont{N}} symbol.  These symbols are obtained by holding down
 the \specialkey{SHIFT} key and tapping either the N or M keys.  You
@@ -1350,13 +1350,13 @@ like:
 This will print one or the other of these symbols each time. We could
 use this already to print the maze by doing this over and over, making
 a loop. We could use \stw{FOR} and \stw{NEXT}. But in this case, we
-want it to go forever, that is, each time the programme gets to the
+want it to go forever, that is, each time the program gets to the
 end, we want it to go to the start again.  The people who created
 BASIC really weren't very creative, so the command to do this is
 called \stw{GOTO}\index{GOTO}\index{BASIC 65 Commands!GOTO}.  You put
 the number of the line that you want to be executed next after it,
 e.g., \stw{GOTO 1}.  We can use this to write our little maze
-programme so that it will run continuously:
+program so that it will run continuously:
 
 \begin{screenoutput}
 10 LET C = 205.5+RND(1)
@@ -1365,7 +1365,7 @@ programme so that it will run continuously:
 \end{screenoutput}
 
 \needspace{4cm}
-If you \stw{RUN} this programme, it will start drawing a maze forever,
+If you \stw{RUN} this program, it will start drawing a maze forever,
 that looks like the screen shot below.  You can stop it at any time by
 pressing the \specialkey{RUN\\STOP} key, or you can pause it by
 pressing the \specialkey{NO\\SCROLL} key, and unpause it by pressing
@@ -1378,7 +1378,7 @@ below, it was working on line 10:
 
 \needspace{2cm}
 That works nicely, and draws a very famous maze \cite{montfort201210}.
-We can, however, make the programme smaller.  We don't need to put the
+We can, however, make the program smaller.  We don't need to put the
 result of the calculation of which symbol to display on a separate
 line.  We can put the calculation directly into brackets for the
 \stw{CHR\$()} function:
@@ -1398,7 +1398,7 @@ command:
 \end{screenoutput}
 
 Can you see how there are often many ways to get the same effect from
-a programme? This is quite normal. For complex programmes, there are
+a program? This is quite normal. For complex programmes, there are
 many, many ways to get the same function.  This is one of the areas
 in computer programming where you can be very creative.
 
@@ -1431,13 +1431,13 @@ we can do something like:
 
 \needspace{3cm}
 That looks much better. So lets type in our ``guess the number''
-programme again. But this time, lets replace the place where we set
+program again. But this time, lets replace the place where we set
 our secret number to the number 23, to instead set it to a random
 integer between 1 and 100.  Don't peek at the solution just yet. Have a
 think about how we can use the above to set \stw{SN} to a random
 integer between 1 and 100.  Once you have your guess ready, have a
 look what I came up with below. You might have made a different
-programme that can do the same job. That's quite fine, too!
+program that can do the same job. That's quite fine, too!
 
 \begin{screenoutput}
 10 SN=INT(RND(1)*100)+1
@@ -1454,15 +1454,15 @@ programme that can do the same job. That's quite fine, too!
 
 Now we don't have to worry about someone guessing the number, and we
 don't need someone else to pick the number for us. This makes the
-programme much more fun to play.  Can you beat it?
+program much more fun to play.  Can you beat it?
 
 
 \subsubsection{Exercises to try}
 
-{\bf 1. Can you make the maze programme make different mazes?}
+{\bf 1. Can you make the maze program make different mazes?}
 
-The maze programme currently displays equal numbers of {\symbolfont{N}}
-and {\symbolfont{M}}. Can you change the programme to print twice as
+The maze program currently displays equal numbers of {\symbolfont{N}}
+and {\symbolfont{M}}. Can you change the program to print twice as
 many of one than the other?  How does the maze look then?
 
 {em Clue: We used \stw{205.5} so that when we add a random number
@@ -1471,11 +1471,11 @@ many of one than the other?  How does the maze look then?
   \stw{205.5} towards \stw{205}, or increase it towards \stw{206} you
   will change the relative proportion of each character that appears.
 
-{\bf 2. Can you modify the ``guess my number'' programme to choose a
+{\bf 2. Can you modify the ``guess my number'' program to choose a
   number between 1 and 10?}
 
-At the moment, the programme picks a number between 1 and 100.  Modify
-the programme so that it picks a number from a different range. Don't
+At the moment, the program picks a number between 1 and 100.  Modify
+the program so that it picks a number from a different range. Don't
 forget to update the message printed to the user.  Do they still need
 10 guesses? Change the maximum number of guesses they get before
 losing to a more suitable amount.
@@ -1485,7 +1485,7 @@ losing to a more suitable amount.
 
 {\bf 3. Set the screen, border and text colour to random colours}
 
-Modify either the maze or ``guess my number'' programme to use
+Modify either the maze or ``guess my number'' program to use
 random colours.  How might you make sure that the text is always
 visible?
 
@@ -1502,10 +1502,10 @@ visible?
   variables have the same number, then you need to change one of
   them.}
 
-{\bf 4. Make the ``guess my number'' programme randomly choose between
+{\bf 4. Make the ``guess my number'' program randomly choose between
   two different greeting messages when it starts.}
 
-The ``guess my number'' programme currently always prints the same
+The ``guess my number'' program currently always prints the same
 message every time it starts.  Modify it so that it prints one of two
 possible messages each time.
 

--- a/ccompilers.tex
+++ b/ccompilers.tex
@@ -22,7 +22,7 @@ tremendous advantage, and not particularly hard to do.  These would
 all be great tasks to tackle while you wait for your MEGA65 DevKit to
 arrive!
 
-An example template for a C programme that can be compiled using CC65
+An example template for a C program that can be compiled using CC65
 and executed on the MEGA65 can be found in the repository
 \url{https://github.com/MEGA65/hello-world}.  This repository will
 even download and compile CC65, if you don't already have it installed

--- a/configuring.tex
+++ b/configuring.tex
@@ -255,7 +255,7 @@ battery-backed RAM, the MEGA65 stores this data on sector 1 of the SD card. If y
 To correct this error, press \megakey{F13}. Then press \megakey{F7} to save the reset configuration, or the reset data will not be saved to the MEGA65 System
 Partition.
 
-Once you have dismissed that display, or if your MEGA65 System Partition was not corrupted, you can begin exploring and adjusting various settings. The programme can be controlled using the keyboard, or optionally, an Amiga(tm) or C1351 mouse.
+Once you have dismissed that display, or if your MEGA65 System Partition was not corrupted, you can begin exploring and adjusting various settings. The program can be controlled using the keyboard, or optionally, an Amiga(tm) or C1351 mouse.
 
 You can advance screens by pressing \megakey{F1}, or use \megakey{F2} to navigate in the opposite direction. Use the \megakey{$\leftarrow$} and \megakey{$\rightarrow$} keys to navigate between screens.
 

--- a/cores-and-flashing.tex
+++ b/cores-and-flashing.tex
@@ -226,16 +226,16 @@ The process is as shown in the following figure: When the MEGA65 is
 powered on, it always starts the bitstream stored in slot 0 of the
 flash.  If that is the MEGA65 Factory Core, the MEGA65 HYPPO
 Hypervisor starts.  If it is the first boot since power-on, HYPPO
-starts the Flash Menu programme -- but note that the Flash Menu in
+starts the Flash Menu program -- but note that the Flash Menu in
 this mode may not show anything on the screen to indicate that it is
 running!
 
 The Flash Menu checks if the system is booting from Flash
 Slot 0.  If it is, it checks if the \specialkey{NO SCROLL} key is being held.  If
-it is, the Flash Menu programme shows its display, allowing the user
+it is, the Flash Menu program shows its display, allowing the user
 to select or re-flash a core. If the \specialkey{NO SCROLL} key is not being
-pressed, then the Flash Menu programme checks if Flash Slot 1 contains a valid
-core.  If it does, then the Flash menu programme attempts to start
+pressed, then the Flash Menu program checks if Flash Slot 1 contains a valid
+core.  If it does, then the Flash menu program attempts to start
 that core.  If it succeeds, then the system reconfigures to that core,
 after which the behaviour of the system is according to that core. If
 it fails, the keyboard will go into ``ambulance mode'' showing flashing blue

--- a/developing-system-programs.tex
+++ b/developing-system-programs.tex
@@ -8,7 +8,7 @@ its own helper programmes, as well as the Flash Menu \index{Flash Menu}\index{ME
 
 A number of these system programmes are pre-loaded into the MEGA65 bitstream, while others live on the SD card.
 For those that are pre-loaded into the MEGA65 bitstream, this works by having areas of pre-initialised memory, that
-contain the appropriate programme.  For example, the utilities accessible via the Utility Menu are all located in
+contain the appropriate program.  For example, the utilities accessible via the Utility Menu are all located in
 the colour RAM, while the Flash Menu is located at \$50000 -- \$57FFF.
 
 In one sense, the easiest way to test new versions of these utilities is to generate a new bitstream with the updated versions.
@@ -23,18 +23,18 @@ The flash menu is located in pre-initialised RAM at \$50000 -- \$57FFFF.  It is 
 MEGA65 is powered on.  It is unusual in that it executes in the hypervisor context. This is so that it has access to the QSPI
 flash, which is not available outside of Hypervisor Mode, so that user programmes cannot corrupt the cores stored in the flash.
 
-It is also important to note that the flash menu programme must fit {\em entirely} below \$8000 when loaded {\em and} executing, as the Hypervisor is still mapped at \$8000 -- \$BFFF, and can easily be corrupted by an ill behaved flash menu programme.  In this regard, the flash menu
+It is also important to note that the flash menu program must fit {\em entirely} below \$8000 when loaded {\em and} executing, as the Hypervisor is still mapped at \$8000 -- \$BFFF, and can easily be corrupted by an ill behaved flash menu program.  In this regard, the flash menu
 can be regarded as an extension of the hypervisor that is discarded after the first boot.
 This is unlike all other system programmes, that operate in a dedicated memory context, from where the Hypervisor is safe from corruption. It also means that you can't crunch the flash menu to make it fit, as it would overwrite the Hypervisor during decrunching.
 
-Also, as the flash menu is executed very early in the boot process, only the pre-included OpenROM ROM image is available.  Thus you must ensure that your flash menu programme is compatible with that ROM.  
+Also, as the flash menu is executed very early in the boot process, only the pre-included OpenROM ROM image is available.  Thus you must ensure that your flash menu program is compatible with that ROM.
 
 The Hypervisor maintains a flag that indicates whether the flash menu has been executed or not. This flag is updated at the point
 where the Hypervisor exits to user mode for the first time, since after that point, the contents of \$50000 -- \$57FFF can no longer
 be trusted to contain the flash menu.  This means that if you wish to have the Hypervisor run a new version of the flash menu that
 you have loaded, you must prevent the Hypervisor from exiting to user mode first.
 
-The easiest way to achieve this is to hold the ALT key down while powering on the MEGA65.  This will cause the Hypervisor to display the Utility Menu, rather than exiting to user mode.  It is safe at this time to use the {\tt m65} utility to load the replacement flash menu programme using a command similar to the following:
+The easiest way to achieve this is to hold the ALT key down while powering on the MEGA65.  This will cause the Hypervisor to display the Utility Menu, rather than exiting to user mode.  It is safe at this time to use the {\tt m65} utility to load the replacement flash menu program using a command similar to the following:
 
 \begin{tcolorbox}[colback=black,coltext=white]
 \verbatimfont{\codefont}
@@ -45,14 +45,14 @@ m65 -@ newflashmenu.prg@50000
 
 That command would load the file {\tt newflashmenu.prg} at memory location \$50000.
 
-After that, you can simply press the reset button the side of the MEGA65i while holding down the NO SCROLL key, and it will boot again, and because it never left Hypervisor Mode during the previous boot cycle, it will run your updated flash menu programme. 
+After that, you can simply press the reset button the side of the MEGA65i while holding down the NO SCROLL key, and it will boot again, and because it never left Hypervisor Mode during the previous boot cycle, it will run your updated flash menu program.
 
 It should also be possible to completely automate this process, by first using {\tt m65 -b} to load a new bitstream, thus simulating a cold boot, and then quickly calling {\tt m65} again to simulate depressing the ALT key (or herhaps simply halting the processor), then {\tt m65 -@ ...} and finally {\tt m65 -F} to reset the machine.  Writing a script or utility that correctly implements this automation is left as an exercise for the reader.
 
 \section{Format/FDISK Utility}
 
 The Format/FDISK utility is accessed as part of the Utility Menu system.  These utilities are compiled, crunched and linked using the
-{\tt utilpacker} programme.  If you have checked out the mega65-core source repository, you can re-build the colour RAM image by using:
+{\tt utilpacker} program.  If you have checked out the mega65-core source repository, you can re-build the colour RAM image by using:
 
 \begin{tcolorbox}[colback=black,coltext=white]
 \verbatimfont{\codefont}
@@ -89,9 +89,9 @@ The process for updating the MEGA65 Configuration utility is essentially the sam
 
 \section{Freeze Menu}
 
-The Freeze Menu is a normal programme, which is stored in {\tt FREEZER.M65} on the SD card's FAT32 file system.
+The Freeze Menu is a normal program, which is stored in {\tt FREEZER.M65} on the SD card's FAT32 file system.
 
-To updated the Freeze Menu, simply use the {\tt m65ftp} utility or some other means to upload your updated FREEZER.M65 file to the SD card's FAT32 file system.  The format of the programme is simply a C64-mode PRG file, just renamed to FREEZER.M65.
+To updated the Freeze Menu, simply use the {\tt m65ftp} utility or some other means to upload your updated FREEZER.M65 file to the SD card's FAT32 file system.  The format of the program is simply a C64-mode PRG file, just renamed to FREEZER.M65.
 
 \section{Freeze Menu Helper Programmes}
 
@@ -99,11 +99,11 @@ The Freeze Menu helper programmes are updated in the same way as the Freeze Menu
 
 \section{Hypervisor}
 
-The Hypervisor is normally built as HICKUP.M65, a 16KiB file that contains the complete Hypervisor programme.  MEGA65 bitstreams contain a pre-build version located at \$FFF8000 -- \$FFFBFFF.  Updated versions of the Hypervisor can be tested using two main approaches:
+The Hypervisor is normally built as HICKUP.M65, a 16KiB file that contains the complete Hypervisor program.  MEGA65 bitstreams contain a pre-build version located at \$FFF8000 -- \$FFFBFFF.  Updated versions of the Hypervisor can be tested using two main approaches:
 
 \begin{itemize}
 	\item 1. Place the updated HICKUP.M65 file on the FAT32 file system of the SD card, and then power the MEGA65 off and on.  This works because the Hypervisor contains code that checks for an updated version of itself, and if found, loads it. However this approach is problematic in that if you install a newer bitstream, it will still downgrade the Hypervisor to whatever version is found in the HICKUP.M65 file on the SD card.  This method is only recommended for developers who have a need to test their modified Hypervisor code from a cold start. Even then, it is recommended to remove the HICKUP.M65 file immediately after testing to avoid unexpected down-grading in the future.
-	\item 2. Use the m65 command's {\\t -k} option to replace the Hypervisor in place, and then reset the MEGA65 using the reset button on the left side of the case.  This should be done when the Hypervisor is {\em not} active, so that corruption of current execution cannot occur. However, it must also occur before any ROM has been loaded to replace the default OpenROM image.  This is because the Hypervisor will attempt to call into the ROM on first-boot in prepration for calling the flash menu, and assumes that the OpenROM is present, because it uses a special OpenROM-specific call to initialise parts of the system state for the flash menu.  This is best done by using a command like {\tt m65 -k bin/HICKUP.M65 -R bin/MEGA65.ROM} to load both a new Hypervisor programme and re-load an OpenROM image.
+	\item 2. Use the m65 command's {\\t -k} option to replace the Hypervisor in place, and then reset the MEGA65 using the reset button on the left side of the case.  This should be done when the Hypervisor is {\em not} active, so that corruption of current execution cannot occur. However, it must also occur before any ROM has been loaded to replace the default OpenROM image.  This is because the Hypervisor will attempt to call into the ROM on first-boot in prepration for calling the flash menu, and assumes that the OpenROM is present, because it uses a special OpenROM-specific call to initialise parts of the system state for the flash menu.  This is best done by using a command like {\tt m65 -k bin/HICKUP.M65 -R bin/MEGA65.ROM} to load both a new Hypervisor program and re-load an OpenROM image.
 \end{itemize}
 
 \section{OpenROM}

--- a/emulators.tex
+++ b/emulators.tex
@@ -56,7 +56,7 @@ will run on both platforms. As previously mentioned, both emulators are a work i
 
 Another link provides access to the MEGA65 Book. This all-in-one volume, of apporixmately 800 pages, contains the official MEGA65 documentation. The majority of this developer's guide is also present in the MEGA65 Book.
 
-This ISO also includes documentation for the C65 Notepad; a programme for the C65 and MEGA65 written by Snoopy (the developer of the Live ISO image). A ``read me'' file contains further information about the Live ISO.
+This ISO also includes documentation for the C65 Notepad; a program for the C65 and MEGA65 written by Snoopy (the developer of the Live ISO image). A ``read me'' file contains further information about the Live ISO.
 
 Finally, on the right-hand side, there are links to download a C65 ROM and to update the MEGA65 Book to the latest version. This will ensure you don't need to create a new bootable image each time a frequent update is made to the MEGA65 Book.
 

--- a/howcomputerswork.tex
+++ b/howcomputerswork.tex
@@ -22,7 +22,7 @@ whether it be sports, knitting, maths or writing. But almost
 everyone is able to learn enough to help them in their life.
 
 We created the MEGA65, because we believe that YOU can learn to
-programme, so that computers can be more useful to you, and as with
+program, so that computers can be more useful to you, and as with
 learning any new skill, that you can have the satisfaction and enjoyment
 and new adventures that this brings!
 
@@ -47,7 +47,7 @@ little egg cups in the egg carton.  Then write the number zero on a little scrap
 \begin{itemize}
   \item First, each cup is allowed to hold exactly one thing at a time. Never more. Never less.  This so that when we ask the question ``what is in box such-and-such,'' that there is a single clear answer. It's also how computer memory works: Each piece of memory can hold only one thing at a time.
 
-  \item Second, we need a way for the computer to know what to do next. On most computers this is called the Programme Counter, or PC, for short (not to be confused with PC when people are talking about a Personal Computer).  The PC is just the number of the next of the next memory location (or in our case, egg-cup), that the computer will examine, when deciding what to do next.  You might like to have another piece of paper that you can use to write the PC number on as you go along.
+  \item Second, we need a way for the computer to know what to do next. On most computers this is called the Program Counter, or PC, for short (not to be confused with PC when people are talking about a Personal Computer).  The PC is just the number of the next of the next memory location (or in our case, egg-cup), that the computer will examine, when deciding what to do next.  You might like to have another piece of paper that you can use to write the PC number on as you go along.
 
   \item Third, we need to have a list of things that the egg-cup computer will do, based on what number is in the egg-cup indicated by the 
     PC.

--- a/images/illustrations/flashmenu-flowchart.svg
+++ b/images/illustrations/flashmenu-flowchart.svg
@@ -841,7 +841,7 @@
        y="360.51968"
        x="468.15952"
        sodipodi:role="line"
-       id="tspan9177">menu programme</tspan></text>
+       id="tspan9177">menu program</tspan></text>
   <path
      sodipodi:nodetypes="cc"
      inkscape:connector-curvature="0"

--- a/index_basic_programmes.c
+++ b/index_basic_programmes.c
@@ -112,7 +112,7 @@ int main(int argc, char** argv)
     fprintf(stderr, "  %s\n", commands[i]);
 
   /*
-    Pass 2: Find example programs, and note which commands should be indexed following each example programme.
+    Pass 2: Find example programs, and note which commands should be indexed following each example program.
    */
   f = fopen(argv[1], "r");
   if (!f) {
@@ -169,7 +169,7 @@ int main(int argc, char** argv)
       fprintf(stdout, "%s", line);
       code_font = 0;
       if (in_code) {
-        // Parse example programme to look for known keywords
+        // Parse example program to look for known keywords
         parse_basic_text(line);
       }
     }

--- a/instruction_sets/inst.JMP
+++ b/instruction_sets/inst.JMP
@@ -1,6 +1,6 @@
 Jump to Address
 PC $\leftarrow$ M2:M1
 
-This instruction sets the Programme Counter (PC) Register
+This instruction sets the Program Counter (PC) Register
 to the address indicated by the instruction, causing
 execution to continue from that address.

--- a/instruction_sets/inst.JSR
+++ b/instruction_sets/inst.JSR
@@ -3,7 +3,7 @@ PC $\leftarrow$ M2:M1, Stack $\leftarrow$ PCH:PCL
 
 This instruction saves the address of the instruction
 following the JSR instruction onto the stack, and
-then sets the Programme Counter (PC) Register
+then sets the Program Counter (PC) Register
 to the address indicated by the instruction, causing
 execution to continue from that address.  Because the
 return address has been saved on the stack, the RTS
@@ -15,4 +15,4 @@ NOTE: This instruction actually pushes the address of
 the last byte of the JSR instruction onto the stack.
 The RTS instruction naturally is aware of this, and
 increments the address on popping it from the stack,
-before setting the Programme Counter (PC) register.
+before setting the Program Counter (PC) register.

--- a/instruction_sets/inst.KIL
+++ b/instruction_sets/inst.KIL
@@ -7,5 +7,5 @@ computer.  On the 45GS02 these instructions cause Hypervisor Traps.
 Or rather, they will, once this functionality has been implemented.
 Thus they can be used to detect whether running on a 6502 or a 45GS02:
 If on a 6502 processor, the instruction will never return, while they
-will cause an exception on a 45GS02, likely causing the calling programme
+will cause an exception on a 45GS02, likely causing the calling program
 to be aborted or crash.

--- a/instruction_sets/inst.RES
+++ b/instruction_sets/inst.RES
@@ -4,5 +4,5 @@ UNDEFINED
 These extended opcodes are reserved, and their function
 is undefined and subject to change in future revisions
 of the 45GS02.  They should therefore not be used in
-any programme.
+any program.
 

--- a/instruction_sets/inst.RESQ
+++ b/instruction_sets/inst.RESQ
@@ -4,5 +4,5 @@ UNDEFINED
 These extended opcodes are reserved, and their function
 is undefined and subject to change in future revisions
 of the 45GS02.  They should therefore not be used in
-any programme.
+any program.
 

--- a/instruction_sets/inst.RSVQ
+++ b/instruction_sets/inst.RSVQ
@@ -4,5 +4,5 @@ UNDEFINED
 These extended opcodes are reserved, and their function
 is undefined and subject to change in future revisions
 of the 45GS02.  They should therefore not be used in
-any programme.
+any program.
 

--- a/instruction_sets/inst.RTI
+++ b/instruction_sets/inst.RTI
@@ -2,8 +2,8 @@ Return From Interrupt
 P $\leftarrow$ STACK, PC $\leftarrow$ STACK, SP $\leftarrow$ SP + 3
 N+V+C+V+D+I+
 This instruction pops the processor flags from the stack, and then
-pops the Programme Counter (PC) register from the stack, allowing
-an interrupted programme to resume.
+pops the Program Counter (PC) register from the stack, allowing
+an interrupted program to resume.
 
 \begin{itemize}
 \item The 6502 Processor Flags are restored from the stack.

--- a/instruction_sets/inst.RTS
+++ b/instruction_sets/inst.RTS
@@ -2,6 +2,6 @@ Return From Subroutine
 PC $\leftarrow$ STACK + N, SP $\leftarrow$ SP + 2 + N
 
 This instruction adds optional argument to the Stack Pointer (SP) Register, and then
-pops the Programme Counter (PC) register from the stack, allowing
+pops the Program Counter (PC) register from the stack, allowing
 a routine to return to its caller.
 

--- a/libc.tex
+++ b/libc.tex
@@ -14,9 +14,9 @@ welcome someone maintaining a KickC port of it.
 The MEGA65 libc is purposely provided in source-form only, and with groups
 of functions in separate files, and with separate header files for including.
 The idea is that you include only the header files that you require, and
-add only the source files required to the list of source files of the programme
+add only the source files required to the list of source files of the program
 you are compiling.  This avoids the risk of the compiler including functions
-in your compiled programme that are never used, and thus wasting precious memory
+in your compiled program that are never used, and thus wasting precious memory
 space.
 
 Note that some library source files are written in C, and thus are present as

--- a/mega65-book.tex
+++ b/mega65-book.tex
@@ -214,7 +214,7 @@
 \vspace{3mm}
 
 {
-C64 and C65 programme and peripheral compatibility ... amazing sound ... true arcade-class graphics
+C64 and C65 program and peripheral compatibility ... amazing sound ... true arcade-class graphics
 ... beautifully finished hardware ... full mechanical keyboard ... rich networking capabilities
 and one of the fastest 6502-class processors avaiable make the MEGA65 truly unique for home, business
 or educational use.

--- a/mega65-developer-guide.tex
+++ b/mega65-developer-guide.tex
@@ -121,7 +121,7 @@ generous work of developers like yourself. So, again, thank you!
 
 But developing for the MEGA65 is not merely a case of giving to the
 benefit of others. We have tried hard to create a machine that is as
-fun to programme as the Commodore 64, but with some of the barriers
+fun to program as the Commodore 64, but with some of the barriers
 and frustrations worn down somewhat.  That is, it is our intention
 that people develop on the MEGA65 because it is fun, and then enjoy
 the process.  That is, the journey should very much be the
@@ -185,26 +185,26 @@ The MEGA65 normally starts in C65 mode, and there is appeal in making
 programmes that can start directly from C65 mode.  However, the
 different versions of the C65 ROM make this difficult, as there are
 differences in the memory location of various system variables and ROM
-routines.  If you are developing a programme in assembly language or
+routines.  If you are developing a program in assembly language or
 C, it is typically easier to develop it for C64 mode.
 
 But that leaves
 you with the problem of how to allow it to be started from C65 mode.
-Our solution to this is the \stw{c65toc65wrapper.asm} programme.  This
-short programme can be found in the \stw{src/utilities} directory of
+Our solution to this is the \stw{c65toc65wrapper.asm} program.  This
+short program can be found in the \stw{src/utilities} directory of
 the \url{https://github.com/mega65/mega65-tools} repository.  When
-compiled, it produces a short programme that you can pre-pend to your
-C64-mode oriented MEGA65 programme, and have it automatically detect
+compiled, it produces a short program that you can pre-pend to your
+C64-mode oriented MEGA65 program, and have it automatically detect
 C64 or C65 mode, switch to C64 mode if required, and set your
-programme going. It also switches the CPU to 40MHz.  The only
-assumption it makes, is that your programme should be started using
+program going. It also switches the CPU to 40MHz.  The only
+assumption it makes, is that your program should be started using
 \stw{SYS 2061}
 
-This programme is particularly handy when using exomizer, as by having
+This program is particularly handy when using exomizer, as by having
 the CPU set to 40MHz before depacking allows depacking to happen
 almost instantly.  This is important on the MEGA65, as loading a
-programme often takes only a fraction of a second, but depacking an
-exomized programme at 1MHz can take several seconds.
+program often takes only a fraction of a second, but depacking an
+exomized program at 1MHz can take several seconds.
 
 Finally, you can use this approach to create bootable disks for the
 MEGA65, by placing the file onto the disk with the

--- a/modes.tex
+++ b/modes.tex
@@ -126,7 +126,7 @@ FOR I = 0 TO 15 STEP 0.2 : POKE 53510,I : NEXT
 \end{verbatim}
 \end{tcolorbox}
 
-Once the programme has been entered, type RUN on a new line. This will make the background of the screen fade from
+Once the program has been entered, type RUN on a new line. This will make the background of the screen fade from
 blue to purple.  If you would like to make the effect progress faster, increase the 0.2 to a larger number, such as 0.5, or to
 make it slower, change it to a smaller number, such as 0.02. You can also change the red component by adding a
 different number to 53504, the green component at 53760 -- 54015 (hex \$D200 -- \$D2FF), or the

--- a/screen-maps.c
+++ b/screen-maps.c
@@ -1,5 +1,5 @@
 /*
-  Programme for generating simple screen map diagrams for the MEGA65 documentation.
+  Program for generating simple screen map diagrams for the MEGA65 documentation.
 
   It is designed to produce maps showing screen addresses in various modes, as well
   as the memory layout corresponding to various actual displays.

--- a/transferanddebugging.tex
+++ b/transferanddebugging.tex
@@ -54,22 +54,22 @@ digital screenshots, it may not exactly match the real display of the
 MEGA65.  At the time of writing it does not render sprites or
 bitplanes, only text and bitmap-based video modes.
 
-\subsection{Load and run a programme on the MEGA65}
+\subsection{Load and run a program on the MEGA65}
 
-To load and run a programme on the MEGA65, you can use a command like:
+To load and run a program on the MEGA65, you can use a command like:
 
 \begin{screenoutput}
 m65 -F -4 -r foo.prg
 \end{screenoutput}
 
 The \stw{-F} option tells \stw{m65} to reset the MEGA65
-before loading the programme.
+before loading the program.
 
 The \stw{-4} option tells \stw{m65} to switch the MEGA65
-to C64 mode before loading the programme. If this is left off, then it
-will attempt to load the programme in C65 mode.
+to C64 mode before loading the program. If this is left off, then it
+will attempt to load the program in C65 mode.
 
-The \stw{-r} option tells \stw{m65} to run the programme
+The \stw{-r} option tells \stw{m65} to run the program
 immediately after loading.
 
 Note that this command works using the normal BASIC LOAD command, and
@@ -85,7 +85,7 @@ m65 -b bitstream.bit
 \end{screenoutput}
 
 This will cause the named bitstream to be sent to the FPGA.  As the
-FPGA will be reconfigured by this action, and programme currently
+FPGA will be reconfigured by this action, and program currently
 running will not merely be stopped, but also main memory will be
 cleared. For models of the MEGA65 that are fitted with 8MB or 16MB of
 expansion memory, those expansion memories are implemented in external
@@ -332,7 +332,7 @@ With this tool you can easily transfer PRG programs and a variety of other files
 The \stw{mega65}\_\stw{ftp} utility from
 the \url{https://github.com/mega65/mega65-tools} repository is a
 little misleadingly named: While it 
-is a File Transfer Programme, it does not use the File Transfer
+is a File Transfer Program, it does not use the File Transfer
 Protocol (FTP).  Rather, it uses the serial monitor interface to take
 remote control of a MEGA65, and directly access its SD card to enable
 copying of files between the MEGA65 and the host computer.
@@ -340,7 +340,7 @@ copying of files between the MEGA65 and the host computer.
 Note that it does not perfectly restore the MEGA65's state on exit,
 and thus should only be used when the MEGA65 is at the READY prompt,
 so that any running software doesn't go haywire. In particular, you
-should avoid using it when a sensitive programme is running, such as
+should avoid using it when a sensitive program is running, such as
 the Freeze Menu, MEGA65 Configuration Utility, or the MEGA65
 Format/FDISK utility.  (This problem could be solved with a little
 effort, if someone has the time and interest to fix it).
@@ -354,7 +354,7 @@ MEGA65's Hypervisor's VFAT32 file system code. Again, these problems
 could be fixed with a modest amount of effort on the part of a
 motivated member of the community.
 
-Finally, the \stw{mega65}\_\stw{ftp} programme is {\em very} slow to push
+Finally, the \stw{mega65}\_\stw{ftp} program is {\em very} slow to push
 new files to the MEGA65, typically yielding speeds of around 5KB/sec.
 This is partly because the serial monitor interface is capable of
 transferring data at only 40KB/sec (when set to 4,000,000 bits per


### PR DESCRIPTION
Care was taken to ensure instances of `Programme` (for example when used with the Program Counter), maintained the capitalisation.

Images with `programme` in the name and references to them were untouched.