### PR TITLE
Basic65 prood read part iv

### DIFF
--- a/appendix-basic65.tex
+++ b/appendix-basic65.tex
@@ -225,7 +225,7 @@ string   array &  3     &    \$    & length = 0 .. 255 & AB\$(X) = "TEXT" \\
 \item [Usage:]  The numeric function {\bf ABS(x)} returns
                 the absolute value of the numeric
                 argument {\bf x}. \\
-               {\bf x} = numeric argument (integer or real expression).
+               {\bf x} numeric argument (integer or real expression).
 \item [Remarks:] The result is of type real.
 \item [Example:] Using {\bf ABS}
 
@@ -311,7 +311,7 @@ In most cases {\bf AND} is used in {\bf IF} statements.
    {\bf SEQ} or {\bf USR} for writing and positions the write pointer
    at the end of the file.
 
-   {\bf lfn} = {\bf l}ogical {\bf f}ile {\bf n}umber \\
+   {\bf lfn} {\bf l}ogical {\bf f}ile {\bf n}umber \\
    1 <= lfn <= 127: line terminator is CR \\
    128 <= lfn <= 255: line terminator is CR LF
 
@@ -420,7 +420,7 @@ In most cases {\bf AND} is used in {\bf IF} statements.
   number for the entry of the next line. The new number is
   computed by adding {\bf step} to the current line number.
 
-  {\bf step} = line number increment
+  {\bf step} line number increment
 
   Typing {\bf AUTO} with no argument switches this function off.
 
@@ -513,8 +513,8 @@ BACKGROUND  3 : REM SELECT BACKGROUND COLOUR CYAN
    For example: CBM 4040, 8050, 8250 via IEEE-488 to IEC adapter.
    The backup is then done by the disk unit internally.
 
-   {\bf source} = unit or drive \# of source disk. \\
-   {\bf target} = unit or drive \# of target disk.
+   {\bf source} unit or drive \# of source disk. \\
+   {\bf target} unit or drive \# of target disk.
 
 \item [Remarks:] The target disk will be formatted and
                  an identical copy of the source disk will be written. \\
@@ -2088,7 +2088,7 @@ RUN
 
    \unitdefinition
 
-   {\bf R} = Recover a previously deleted file.
+   {\bf R} Recover a previously deleted file.
    This will only work if there were no write operations
    between deletion and recovery, which may have altered the
    contents of the file.
@@ -2407,17 +2407,17 @@ DIR W
 
    {\bf command} 0 = copy, 1 = mix, 2 = swap, 3 = fill
 
-   {\bf length} = number of bytes
+   {\bf length} number of bytes
 
-   {\bf source address} = 16 bit address of read area or fill byte
+   {\bf source address} 16 bit address of read area or fill byte
 
-   {\bf source bank} = bank number for source (ignored for fill mode)
+   {\bf source bank} bank number for source (ignored for fill mode)
 
-   {\bf target} = 16 bit address of write area
+   {\bf target} 16 bit address of write area
 
-   {\bf target bank} = bank number for target
+   {\bf target bank} bank number for target
 
-   {\bf sub} = sub command
+   {\bf sub} sub command
 
 \item [Remarks:]
 The {\bf DMA} command has access to the lower 1 MB address range
@@ -2525,7 +2525,7 @@ DMA 2, 80, 2048, 0, 2048+80, 0 :REM SWAP CONTENTS OF LINE 1 & 2 OF SCREEN
 \item [Usage:]
    Opens a file for reading, or writing.
 
-   {\bf lfn} = {\bf l}ogical {\bf f}ile {\bf n}umber \\
+   {\bf lfn} {\bf l}ogical {\bf f}ile {\bf n}umber \\
    1 <= lfn <= 127: line terminator is CR \\
    128 <= lfn <= 255: line terminator is CR LF
 
@@ -2862,22 +2862,22 @@ ok.
    The {\bf EDMA} ("Extended Direct Memory Access") command is the fastest way
    to manipulate memory areas using the DMA controller.
 
-   {\bf command} 0 = copy, 1 = mix, 2 = swap, 3 = fill
+   {\bf command} 0 = copy, 1 = mix, 2 = swap, 3 = fill.
 
-   {\bf length} = number of bytes (maximum = 65535)
+   {\bf length} number of bytes (maximum = 65535).
 
-   {\bf source} = 28-bit address of read area or fill byte
+   {\bf source}  28-bit address of read area or fill byte.
 
-   {\bf target} = 28-bit address of write area
+   {\bf target} 28-bit address of write area.
 
-   {\bf sub} = sub command (see chapter on DMA controller)
+   {\bf sub} sub command (see chapter on DMA controller).
 
-   {\bf mod} = modifier (see chapter on DMA controller)
+   {\bf mod} modifier (see chapter on DMA controller).
 
 \item [Remarks:]
-The {\bf EDMA} command can access to the whole 256 MB address range
-using up to 28 bit for the addresses of source and target.
-\item [Example:] Using {\bf EDMA}
+The {\bf EDMA} command can access the entire 256 MB address range,
+using up to 28 bits for the addresses of the source and target.
+\item [Examples:] Using {\bf EDMA}
 \begin{tcolorbox}[colback=black,coltext=white]
 \verbatimfont{\codefont}
 \begin{verbatim}
@@ -2897,10 +2897,10 @@ EDMA 0, 80*25, 2048, $8000800 :REM COPY SCREEN TO ATTIC RAM
 \index{EL}
 \index{BASIC 65 System Variables!EL}
 \begin{description}[leftmargin=2cm,style=nextline]
-\item [Format:] {\bf EL} is a reserved system variable
-\item [Usage:]  {\bf EL} has the value of the line, where
-               the latest BASIC error
-               occurred or the value -1 if there was no error.
+\item [Format:] {\bf EL} is a reserved system variable.
+\item [Usage:]  {\bf EL} has the value of the line where
+               the most recent BASIC error occurred,
+                or the value -1 if there was no error.
 
 This variable is typically used in a TRAP routine,
 where the error line is taken from {\bf EL}.
@@ -2932,7 +2932,7 @@ where the error line is taken from {\bf EL}.
 \item [Token:] \$FE \$30
 \item [Format:] {\bf ELLIPSE xcentre, ycentre,
                 xradius, yradius, [,solid]}
-\item [Usage:] As the name says, it draws an ellipse.
+\item [Usage:] Draws an ellipse.
 
                {\bf xcentre} x coordinate of centre in pixels.
 
@@ -2942,7 +2942,7 @@ where the error line is taken from {\bf EL}.
 
                {\bf yradius} y radius of the ellipse in pixels.
 
-               {\bf solid} will fill the ellipse if not zero.
+               {\bf solid} fills the ellipse, if not zero.
 
 \item [Remarks:] The {\bf ELLIPSE} command is used to draw ellipses on
                screens with various resolutions.
@@ -2990,20 +2990,20 @@ where the error line is taken from {\bf EL}.
 \item [Usage:] The {\bf ELSE} keyword is part of an {\bf IF}
                statement.
 
-               {\bf expression} is a logical or numeric expression.
+               {\bf expression} a logical or numeric expression.
                A numerical expression is evaluated as {\bf FALSE}
-               if the value is zero and {\bf TRUE} for any non zero
+               if the value is zero and {\bf TRUE} for any non-zero
                value.
 
-               {\bf true clause} are one or more statements starting
+               {\bf true clause} one or more statements starting
                directly after {\bf THEN} on the same line.
-               A linenumber after {\bf THEN} performs a
-               {\bf GOTO} to that line.
+               A line number after {\bf THEN} performs a
+               {\bf GOTO} to that line instead.
 
-               {\bf false clause} are one or more statements starting
+               {\bf false clause} one or more statements starting
                directly after {\bf ELSE} on the same line.
                A linenumber after {\bf ELSE} performs a
-               {\bf GOTO} to that line.
+               {\bf GOTO} to that line instead.
 
 \item [Remarks:]
                The standard {\bf IF ... THEN ... ELSE} structure
@@ -3048,10 +3048,10 @@ where the error line is taken from {\bf EL}.
 
 \item [Remarks:]
                {\bf END} does {\bf not} clear channels or close files.
-               Also variable definitions are still valid after {\bf END}.
+               Also, variable definitions are still valid after {\bf END}.
                The program may be continued with the {\bf CONT}
-               statement. After executing the very last line of the
-               program {\bf END} is executed automatically.
+               statement. After executing the last line of a
+               program, {\bf END} is executed automatically.
 
 
 \item [Example:]
@@ -3081,22 +3081,21 @@ where the error line is taken from {\bf EL}.
                the parameters for the synthesis of a musical
                instrument.
 
-      {\bf n} = envelope slot (0 -> 9)
+      {\bf n} envelope slot (0-9).
 
-      {\bf attack} = attack rate (0 -> 15)
+      {\bf attack} attack rate (0-15).
 
-      {\bf decay} = decay rate (0 -> 15)
+      {\bf decay} decay rate (0-15).
 
-      {\bf sustain} = sustain rate (0 -> 15)
+      {\bf sustain} sustain rate (0-15).
 
-      {\bf release} = release rate (0 -> 15)
+      {\bf release} release rate (0-15).
 
-      {\bf waveform} = (0:triangle, 1:sawtooth, 2:square/pulse, 3:noise,
-                       4:ring modulation)
+      {\bf waveform} 0:triangle, 1:sawtooth, 2:square/pulse, 3:noise, 4:ring modulation.
 
-      {\bf pw} = pulse width (0 -> 4095) for waveform = pulse.
+      {\bf pw} pulse width (0-4095) for waveform.
 
-               There are 10 slots for storing tunes,
+               There are 10 slots for storing melodies,
                preset with following values:
 
 \ttfamily
@@ -3152,28 +3151,29 @@ where the error line is taken from {\bf EL}.
 
    \unitdefinition
 
-   {\bf R} = Recover a previously erased file.
+   {\bf R} Recover a previously erased file.
    This will only work, if there were no write operations
    between erasing and recovery, which may have altered the
    contents of the file.
 
-\item [Remarks:] The {\bf ERASE filename} command works like the
+\item [Remarks:] The {\bf ERASE filename} command works similarly to the
                  {\bf SCRATCH filename} command.
 
                  The success and the number of erased files can
                  be examined by printing or using the system
-                 variable DS\$. The second last number, which
-                 reports the track number in case of an disk error,
-                 now reports the number of successfully erased files.
+                 variable {\bf DS\$}. The second to last number from {\bf DS\$}
+                 contains the number of successfully erased files,
+                 (normally the second to last number in {\bf DS\$}
+                 contains the track number in case of a disk error).
 
-\item [Example:] Using {\bf ERASE}
+\item [Examples:] Using {\bf ERASE}
 \begin{tcolorbox}[colback=black,coltext=white]
 \verbatimfont{\codefont}
 \begin{verbatim}
-  SCRATCH "DRM",U9 :REM SCRATCH FILE DRM ON UNIT 9
+  ERASE "DRM",U9 :REM ERASE FILE DRM ON UNIT 9
   PRINT DS$
   01, FILES SCRATCHED,01,00
-  SCRATCH "OLD*"   :REM SCRATCH ALL FILES BEGINNING WITH "OLD"
+  ERASE "OLD*"   :REM ERASE ALL FILES BEGINNING WITH "OLD"
   PRINT DS$
   01, FILES SCRATCHED,04,00
 \end{verbatim}
@@ -3189,9 +3189,9 @@ where the error line is taken from {\bf EL}.
 \index{ER}
 \index{BASIC 65 System Variables!ER}
 \begin{description}[leftmargin=2cm,style=nextline]
-\item [Format:] {\bf ER} is a reserved system variable
-\item [Usage:]  {\bf ER} has the value of the latest BASIC error
-               occurred or the value -1 if there was no error.
+\item [Format:] {\bf ER} is a reserved system variable.
+\item [Usage:]  {\bf ER} has the value of the latest BASIC error that has
+               occurred or -1 if there was no error.
 
 This variable is typically used in a TRAP routine,
 where the error number is taken from {\bf ER}.
@@ -3367,17 +3367,17 @@ PRINT EXP(LOG(2))
 \item [Format:] {\bf FILTER sid [,freq, lp, bp, hp, res]}
 \item [Usage:] Sets the parameters for sound filter.
 
-      {\bf sid} = 1 : right SID, 2 : left SID
+      {\bf sid} 1 : right SID, 2 : left SID
 
-      {\bf freq} = filter cut off frequency (0 -> 2047)
+      {\bf freq} filter cut off frequency (0 -> 2047)
 
-      {\bf lp} = low pass filter (0:off, 1:on)
+      {\bf lp} low pass filter (0:off, 1:on)
 
-      {\bf bp} = band pass filter (0:off, 1:on)
+      {\bf bp} band pass filter (0:off, 1:on)
 
-      {\bf hp} = high pass filter (0:off, 1:on)
+      {\bf hp} high pass filter (0:off, 1:on)
 
-      {\bf resonance} = resonance (0 -> 15)
+      {\bf resonance} resonance (0 -> 15)
 
 \item [Remarks:] Missing parameter keep their current value.
                  The effective filter is the sum of
@@ -4296,7 +4296,7 @@ PRINT HEX$(10),HEX$(100),HEX$(1000.9)
 
                {\bf expression} is a logical or numeric expression.
                A numerical expression is evaluated as {\bf FALSE}
-               if the value is zero and {\bf TRUE} for any non zero
+               if the value is zero and {\bf TRUE} for any non-zero
                value.
 
                {\bf true clause} are one or more statements starting
@@ -4356,7 +4356,7 @@ PRINT HEX$(10),HEX$(100),HEX$(1000.9)
                the prompt. If the separator is a semicolon,
                a question mark and a space is added to the prompt.
 
-               {\bf variable list} = list of one or more
+               {\bf variable list} list of one or more
                variables, that receive the input.
 
                The input will be processed after the user hits RETURN.
@@ -4408,10 +4408,10 @@ PRINT HEX$(10),HEX$(100),HEX$(1000.9)
                and assigns the data
                to the variables in the list.
 
-               {\bf channel} = channel number assigned
+               {\bf channel} channel number assigned
                by a {\bf DOPEN} or {\bf OPEN} command.
 
-               {\bf variable list} = list of one or more
+               {\bf variable list} list of one or more
                variables, that receive the input.
 
                The input record must be terminated by a
@@ -4709,9 +4709,9 @@ KEY 16,"RUN "+CHR$(34)+"*"+CHR$(34)+CHR$(13)
                If the length of {\bf string} is equal or less than {\bf n},
                the result string will be identical to the argument string.
 
-               {\bf string} = a string expression
+               {\bf string} a string expression
 
-               {\bf n} = a numeric expression (0 -> 255)
+               {\bf n} a numeric expression (0 -> 255)
 
 \item [Remarks:] Empty strings and zero lengths are legal values.
 
@@ -4738,7 +4738,7 @@ MEGA
 \item [Format:] {\bf LEN(string)}
 \item [Usage:] Returns the length of the string.
 
-               {\bf string} = a string expression
+               {\bf string} a string expression
 
 \item [Remarks:] There is no terminating character, like the
                  NULL character in C programs. The length of
@@ -4840,10 +4840,10 @@ A=5      :REM SHORTER AND FASTER
                An empty line consisting of the {\bf RETURN} character only
                will therefore assign an empty string to the variable.
 
-               {\bf channel} = channel number assigned
+               {\bf channel} channel number assigned
                by a {\bf DOPEN} or {\bf OPEN} command.
 
-               {\bf variable list} = list of one or more
+               {\bf variable list} list of one or more
                variables, that receive the input.
 
                The input record must be terminated by a
@@ -4958,7 +4958,7 @@ LIST P "MURX" :REM LIST FILE "MURX" IN PAGE MODE
    The unit number is optional.
    If not present, the default disk device is assumed.
 
-   If {\bf flag} has a non zero value, the file is loaded to
+   If {\bf flag} has a non-zero value, the file is loaded to
    the address, which is read from the first two bytes of the file.
    Otherwise it is loaded to the start of BASIC memory and
    the load address in the file is ignored.
@@ -5264,11 +5264,11 @@ PRINT LOG10(100);LOG(10);LOG(0.1);LOG(0.01)
                 which returns a string or as a statement for
                 inserting sub-strings into an existing string.
 
-               {\bf string} = a string expression
+               {\bf string} a string expression
 
-               {\bf index} = start index (0 -> 255)
+               {\bf index} start index (0 -> 255)
 
-               {\bf n} = length of sub-string (0 -> 255)
+               {\bf n} length of sub-string (0 -> 255)
 
 \item [Remarks:] Empty strings and zero lengths are legal values.
 
@@ -5368,11 +5368,11 @@ FOR I = 0 TO 8: PRINT MOD(I,4);: NEXT I
                 and connects the mouse at the specified port
                 with the mouse pointer sprite.
 
-                {\bf port} = mouse port 1, 2 (default) or 3 (both).
+                {\bf port} mouse port 1, 2 (default) or 3 (both).
 
-                {\bf sprite} = sprite number for mouse pointer (default 0).
+                {\bf sprite} sprite number for mouse pointer (default 0).
 
-                {\bf pos} = initial mouse position (x,y).
+                {\bf pos} initial mouse position (x,y).
 
                 The {\bf MOUSE OFF} command disables the mouse
                 driver and frees the associated sprite.
@@ -5407,10 +5407,11 @@ FOR I = 0 TO 8: PRINT MOD(I,4);: NEXT I
                 which specify either an absolute coordinate, a relative coordinate,
                 an angle or a speed. The value type is determined by a prefix:
 
-                +value = relative coordinate: positive offset \\
-                -value = relative coordinate: negative offset \\
-                \#value = speed \\
-                no prefix = absolute coordinate or angle
+                {\bf +value} relative coordinate: positive offset \\
+                {\bf -value} relative coordinate: negative offset \\
+                {\bf \#value} speed \\
+
+                If no prefix is given, the absolute coordinate or angle is used.
 
   So the position argument can be used to either \\
 - set the sprite to an absolute position on screen, \\
@@ -5434,22 +5435,22 @@ FOR I = 0 TO 8: PRINT MOD(I,4);: NEXT I
                 happens concurrently with the program execution.
 
 
-                {\bf number} = sprite number (0-7)
+                {\bf number} sprite number (0-7)
 
-                {\bf position} = x,y | xrel,y | x,yrel | xrel,yrel | angle\#speed
+                {\bf position} x,y | xrel,y | x,yrel | xrel,yrel | angle\#speed
 
-                {\bf x} = absolute screen coordinate [pixel].
+                {\bf x} absolute screen coordinate [pixel].
 
-                {\bf y} = absolute screen coordinate [pixel].
+                {\bf y} absolute screen coordinate [pixel].
 
-                {\bf xrel} = relative screen coordinate [pixel].
+                {\bf xrel} relative screen coordinate [pixel].
 
-                {\bf yrel} = relative screen coordinate [pixel].
+                {\bf yrel} relative screen coordinate [pixel].
 
-                {\bf angle} = compass direction for sprite movement [degrees].
+                {\bf angle} compass direction for sprite movement [degrees].
                 0 = up, 90 = right, 180 = down, 270 = left, 45 upper right, etc.
 
-                {\bf speed} = speed of movement, a floating point number in the
+                {\bf speed} speed of movement, a floating point number in the
                 range (0.0 to 127.0) uses the the unit (pixel/frame).
                 PAL mode has 50 frames per second and NTSC 60 frames per second.
                 A speed value of 1.0 will move the sprite 50 pixels per second
@@ -5725,11 +5726,11 @@ In most cases the {\bf NOT} will be used in {\bf IF} statements.
    Opens an input/output channel for
    a device.
 
-   {\bf lfn} = {\bf l}ogical {\bf f}ile {\bf n}umber \\
+   {\bf lfn} {\bf l}ogical {\bf f}ile {\bf n}umber \\
    1 <= lfn <= 127: line terminator is CR \\
    128 <= lfn <= 255: line terminator is CR LF
 
-   {\bf first address} = device number.
+   {\bf first address} device number.
    For IEC devices the unit number is the primary address.
    Following primary address values are possible:
 
@@ -5892,17 +5893,17 @@ In most cases the {\bf OR} will be used in {\bf IF} statements.
                 {\bf PALETTE RESTORE} resets the system palette to
                 the default values.
 
-                {\bf screen} = screen number 0 -> 3.
+                {\bf screen} screen number 0 -> 3.
 
-                {\bf COLOR} = keyword for changing system palette.
+                {\bf COLOR} keyword for changing system palette.
 
-                {\bf colour} = index to palette 0 -> 255.
+                {\bf colour} index to palette 0 -> 255.
 
-                {\bf red} = red intensity 0 -> 15.
+                {\bf red} red intensity 0 -> 15.
 
-                {\bf green} = green intensity 0 -> 15.
+                {\bf green} green intensity 0 -> 15.
 
-                {\bf blue} = blue intensity 0 -> 15.
+                {\bf blue} blue intensity 0 -> 15.
 
 \item [Example:] Using {\bf PALETTE}
 
@@ -6013,13 +6014,13 @@ In most cases the {\bf OR} will be used in {\bf IF} statements.
 \item [Format:] {\bf PEN [pen,] colour}
 \item [Usage:]  Sets the colour for the graphic pen.
 
-                {\bf pen} = pen number ( 0 -> 2 )
+                {\bf pen} pen number ( 0 -> 2 )
 
                 pen 0 : drawing pen (default, if only single parameter provided) \\
                 pen 1 : off bits in jam2 mode \\
                 pen 2 : currently unused
 
-                {\bf colour} = palette index.
+                {\bf colour} palette index.
 
 \item [Remarks:] The colour selected by {\bf PEN} will be used by all
                  graphic/drawing commands that follow after it.
@@ -6066,9 +6067,9 @@ In most cases the {\bf OR} will be used in {\bf IF} statements.
 \item [Format:] {\bf PIXEL(x,y)}
 \item [Usage:]  Returns colour at given position.
 
-               {\bf x} = absolute screen coordinate [pixel].
+               {\bf x} absolute screen coordinate [pixel].
 
-               {\bf y} = absolute screen coordinate [pixel].
+               {\bf y} absolute screen coordinate [pixel].
 \end{description}
 
 
@@ -6360,17 +6361,17 @@ HELLO
                The polygon is drawn using the current drawing context
                set with SCREEN, PALETTE and PEN.
 
-               {\bf x,y} = centre coordinates.
+               {\bf x,y} centre coordinates.
 
-               {\bf xrad,yrad} = radius in x- and y-direction.
+               {\bf xrad,yrad} radius in x- and y-direction.
 
-               {\bf sides} = number of polygon sides.
+               {\bf sides} number of polygon sides.
 
-               {\bf drawsides} = sides to draw.
+               {\bf drawsides} sides to draw.
 
-               {\bf subtend} = 1: draw line from centre to start.
+               {\bf subtend} 1: draw line from centre to start.
 
-               {\bf angle} = start angle.
+               {\bf angle} start angle.
 
                {\bf solid} = fill (1) or outline (0).
 
@@ -6406,7 +6407,7 @@ HELLO
 \item [Usage:]  Returns the cursor column relative to the
                 currently used window.
 
-                {\bf dummy} = a numeric value, which is ignored.
+                {\bf dummy} a numeric value, which is ignored.
 
 \item [Remarks:] {\bf POS} gives the column position for the screen
                  cursor. It will not work for redirected output.
@@ -6434,7 +6435,7 @@ HELLO
 \item [Format:] {\bf POT(paddle)}
 \item [Usage:]  Returns the position of a paddle.
 
-                {\bf paddle} = paddle number 1 -> 4.
+                {\bf paddle} paddle number 1 -> 4.
 
                 The low byte of the return value is the
                 paddle value
@@ -6786,7 +6787,7 @@ RUN
 \item [Format:] {\bf READ variable list}
 \item [Usage:]  Reads values from program source into variables.
 
-                {\bf variable list} = any legal variables.
+                {\bf variable list} any legal variables.
 
                All type of constants (integer, real,
                strings) can be read, but no expressions.
@@ -6842,11 +6843,11 @@ RUN
 \item [Format:] {\bf RECORD\#lfn, record, [,byte]}
 \item [Usage:]  Positions the read/write pointer of a relative file.
 
-                {\bf lfn} = {\bf l}ogical {\bf f}ile {\bf n}umber
+                {\bf lfn} {\bf l}ogical {\bf f}ile {\bf n}umber
 
-                {\bf record} = target record ( 1 -> 65535 ).
+                {\bf record} target record ( 1 -> 65535 ).
 
-                {\bf byte} = byte position in record.
+                {\bf byte} byte position in record.
 
                 This command can be used only for files of
                 type {\bf REL}, which are relative files capable
@@ -7221,9 +7222,9 @@ RUN
                If the length of {\bf string} is equal or less than {\bf n},
                the result string will be identical to the argument string.
 
-               {\bf string} = a string expression
+               {\bf string} a string expression
 
-               {\bf n} = a numeric expression (0 -> 255)
+               {\bf n} a numeric expression (0 -> 255)
 
 \item [Remarks:] Empty strings and zero lengths are legal values.
 
@@ -7250,11 +7251,11 @@ PRINT RIGHT$("MEGA-65",2)
 \item [Format:] {\bf RMOUSE xvar, yvar, butvar}
 \item [Usage:] Reads mouse position and button status.
 
-               {\bf xvar} = numerical variable receiving x-position.
+               {\bf xvar} numerical variable receiving x-position.
 
-               {\bf yvar} = numerical variable receiving y-position.
+               {\bf yvar} numerical variable receiving y-position.
 
-               {\bf butvar} = numerical variable receiving button status. \\
+               {\bf butvar} numerical variable receiving button status. \\
                left button sets bit 7, while right button sets bit 0.
 
 {\setlength{\tabcolsep}{1mm}
@@ -7341,11 +7342,11 @@ if the mouse is not connected or disabled.
 \item [Usage:]  Returns the red, green or blue value of
                 a palette colour index.
 
-                {\bf screen} = screen number (0-3).
+                {\bf screen} screen number (0-3).
 
-                {\bf index} = palette colour index.
+                {\bf index} palette colour index.
 
-                {\bf rgb} = (red=0, green=1, blue=2).
+                {\bf rgb} (red=0, green=1, blue=2).
 
 \item [Example:] Using {\bf RPALETTE}
 
@@ -7378,7 +7379,7 @@ PALETTE INDEX 3 RGB = 0  15  15
 \item [Format:] {\bf RPEN(n)}
 \item [Usage:]  Returns the colour index of pen n.
 
-                {\bf n} = PEN number (0-2).
+                {\bf n} PEN number (0-2).
 
 {\ttfamily
                 0: draw pen \\
@@ -7445,15 +7446,15 @@ DRAW PEN COLOUR =  1
 \item [Usage:] Reads the values, that were in the CPU registers
                after a SYS call, into the specified variables.
 
-               {\bf areg} = variable gets accumulator value.
+               {\bf areg} variable gets accumulator value.
 
-               {\bf xreg} = variable gets X register value.
+               {\bf xreg} variable gets X register value.
 
-               {\bf yreg} = variable gets Y register value.
+               {\bf yreg} variable gets Y register value.
 
-               {\bf zreg} = variable gets Z register value.
+               {\bf zreg} variable gets Z register value.
 
-               {\bf sreg} = variable gets status register value.
+               {\bf sreg} variable gets status register value.
 
 \item [Remarks:] The register values after a SYS call are stored
                  in system memory. This enables the command
@@ -7485,9 +7486,9 @@ DRAW PEN COLOUR =  1
 \item [Format:] {\bf RSPCOLOR(n)}
 \item [Usage:]  Returns multi-colour sprite colours.
 
-                {\bf n} = 1 : get multi-colour \# 1.
+                {\bf n} 1 : get multi-colour \# 1.
 
-                {\bf n} = 2 : get multi-colour \# 2.
+                {\bf n} 2 : get multi-colour \# 2.
 
 
 \item [Remarks:] See also {\bf SPRITE} and {\bf SPRCOLOR}.
@@ -7516,7 +7517,7 @@ DRAW PEN COLOUR =  1
 \item [Format:] {\bf RSPEED(n)}
 \item [Usage:]  Returns the current CPU clock in MHz.
 
-                {\bf n} = numerical dummy argument ignored.
+                {\bf n} numerical dummy argument ignored.
 
 \item [Remarks:] See also {\bf SPEED}. \\
                  {\bf RSPEED(n)} will not return correct values,
@@ -7550,11 +7551,11 @@ DRAW PEN COLOUR =  1
 
                 {\bf sprite} : sprite number.
 
-                {\bf n} = 0 : get X position.
+                {\bf n} 0 : get X position.
 
-                {\bf n} = 1 : get Y position.
+                {\bf n} 1 : get Y position.
 
-                {\bf n} = 2 : get speed.
+                {\bf n} 2 : get speed.
 
 
 \item [Remarks:] See also {\bf SPRITE} and {\bf MOVSPR}.
@@ -7586,17 +7587,17 @@ DRAW PEN COLOUR =  1
 
                 {\bf sprite} : sprite number (0 -> 7)
 
-                {\bf n} = 0 : turned on (0 or 1).
+                {\bf n} 0 : turned on (0 or 1).
 
-                {\bf n} = 1 : foreground colour (0 -> 15)
+                {\bf n} 1 : foreground colour (0 -> 15)
 
-                {\bf n} = 2 : background priority (0 or 1).
+                {\bf n} 2 : background priority (0 or 1).
 
-                {\bf n} = 3 : X-expanded (0 or 1).
+                {\bf n} 3 : X-expanded (0 or 1).
 
-                {\bf n} = 4 : Y-expanded (0 or 1).
+                {\bf n} 4 : Y-expanded (0 or 1).
 
-                {\bf n} = 5 : multi-colour (0 or 1).
+                {\bf n} 5 : multi-colour (0 or 1).
 
 \item [Remarks:] See also {\bf SPRITE} and {\bf MOVSPR}.
 
@@ -7682,11 +7683,11 @@ DRAW PEN COLOUR =  1
 \item [Format:] {\bf RWINDOW(n)}
 \item [Usage:]  Returns information regarding the current text window
 
-                {\bf n} = 0 : get width of current text window.
+                {\bf n} 0 : get width of current text window.
 
-                {\bf n} = 1 : get height of current text window.
+                {\bf n} 1 : get height of current text window.
 
-                {\bf n} = 2 : get width of screen (40 or 80).
+                {\bf n} 2 : get width of screen (40 or 80).
 
 \item [Remarks:] See also {\bf WINDOW}. \\
                  Older versions of {\bf RWINDOW} reported
@@ -7811,7 +7812,7 @@ DRAW PEN COLOUR =  1
 
    \unitdefinition
 
-   {\bf R} = Recover a previously erased file.
+   {\bf R} Recover a previously erased file.
    This will only work, if there were no write operations
    between erasure and recovery, which may have altered the
    contents of the file.
@@ -7878,9 +7879,9 @@ DRAW PEN COLOUR =  1
                 If no screen number is given, screen 0 is used. To keep
                    this approach as simple as possible, it is suggested to
                    use the default screen 0.
-                \item {\bf width} = 320 or 640 (default = 320)
-                \item {\bf height} = 200 or 400 (default = 200)
-                \item {\bf depth} = 1..8 (default = 8),
+                \item {\bf width} 320 or 640 (default 320)
+                \item {\bf height} 200 or 400 (default = 200)
+                \item {\bf depth} 1..8 (default = 8),
                    colours = 2 \textasciicircum depth.
                \end{itemize}
 
@@ -7944,10 +7945,10 @@ DRAW PEN COLOUR =  1
                 whether high resolution (1) or low resolution (0) is chosen.
 
                 \begin{itemize}
-                  \item {\bf screen} = screen number 0-3
-                  \item {\bf width flag} = 0-1 (0:320, 1:640 pixel)
-                  \item {\bf height flag} = 0-1 (0:200, 1:400 pixel)
-                  \item {\bf depth} = 1-8 (2 - 256 colours)
+                  \item {\bf screen} screen number 0-3
+                  \item {\bf width flag} 0-1 (0:320, 1:640 pixel)
+                  \item {\bf height flag} 0-1 (0:200, 1:400 pixel)
+                  \item {\bf depth} 1-8 (2 - 256 colours)
                 \end{itemize}
 
                 Note that the width and height values here are {\bf flags},
@@ -8063,7 +8064,7 @@ DRAW PEN COLOUR =  1
 
                -1 for a negative argument \\
                 0 for a zero              \\
-                1 for a positive, non zero argument
+                1 for a positive, non-zero argument
 
 \item [Example:] Using {\bf SGN}
 \begin{tcolorbox}[colback=black,coltext=white]
@@ -8152,22 +8153,22 @@ DRAW PEN COLOUR =  1
 
 \item [Usage:] plays a sound effect.
 
-               {\bf voice} = voice number ( 1 -> 6 ).
+               {\bf voice} voice number ( 1 -> 6 ).
 
-               {\bf freq} = frequency ( 0 -> 65535 ).
+               {\bf freq} frequency ( 0 -> 65535 ).
 
-               {\bf dur} = duration ( 0 -> 32767) .
+               {\bf dur} duration ( 0 -> 32767) .
 
-               {\bf dir} = direction (0:up, 1:down, 2:oscillate).
+               {\bf dir} direction (0:up, 1:down, 2:oscillate).
 
-               {\bf min} = minimum frequency ( 0 -> 65535 ).
+               {\bf min} minimum frequency ( 0 -> 65535 ).
 
-               {\bf sweep} = sweep range ( 0 -> 65535 ).
+               {\bf sweep} sweep range ( 0 -> 65535 ).
 
-               {\bf wave} = waveform (0:triangle, 1:saw, 2:square,
+               {\bf wave} waveform (0:triangle, 1:saw, 2:square,
                3:noise).
 
-               {\bf pulse} = pulse width ( 0 -> 5095 ).
+               {\bf pulse} pulse width ( 0 -> 5095 ).
 
 For details on sound programming, read the {\bf SOUND} chapter.
 
@@ -8315,19 +8316,19 @@ RUN
 
                 The last form switches a sprite on or off and sets its attributes.
 
-                {\bf no} = sprite number
+                {\bf no} sprite number
 
-                {\bf switch} = 1:ON, 0:OFF
+                {\bf switch} 1:ON, 0:OFF
 
-                {\bf colour} = sprite foreground colour
+                {\bf colour} sprite foreground colour
 
-                {\bf prio} = sprite(1) or screen(0) priority
+                {\bf prio} sprite(1) or screen(0) priority
 
-                {\bf expx} = 1:sprite X expansion
+                {\bf expx} 1:sprite X expansion
 
-                {\bf expy} = 1:sprite Y expansion
+                {\bf expy} 1:sprite Y expansion
 
-                {\bf mode} = 1:multi colour sprite
+                {\bf mode} 1:multi colour sprite
 
 \item [Remarks:] The command {\bf SPRCOLOR} must be used to set
                 additional colours
@@ -8362,9 +8363,9 @@ RUN
 \item [Format:] {\bf SPRSAV source, destination}
 \item [Usage:]  Copies sprite data.
 
-                {\bf source} = sprite number or string variable.
+                {\bf source} sprite number or string variable.
 
-                {\bf destination} = sprite number or string variable.
+                {\bf destination} sprite number or string variable.
 
 \item [Remarks:] Both, source and destination can be either
                 a sprite number or a string variable.
@@ -8426,7 +8427,7 @@ RUN
 \index{ST}
 \index{BASIC 65 System Variables!ST}
 \begin{description}[leftmargin=2cm,style=nextline]
-\item [Format:] {\bf ST} is a reserved system variable
+\item [Format:] {\bf ST} is a reserved system variable.
 \item [Usage:]  {\bf ST} holds the status of the last input/output operation.
                 ST is set to zero, if there was no error, otherwise
                 it is set to a device dependent error code.
@@ -8583,17 +8584,17 @@ THE VALUE OF PI IS 3.14159265
                will be saved and the execution of the BASIC program
                continues.
 
-               {\bf address} = start address of the subroutine.
+               {\bf address} start address of the subroutine.
 
-               {\bf areg} = variable gets accumulator value.
+               {\bf areg} variable gets accumulator value.
 
-               {\bf xreg} = variable gets X register value.
+               {\bf xreg} variable gets X register value.
 
-               {\bf yreg} = variable gets Y register value.
+               {\bf yreg} variable gets Y register value.
 
-               {\bf zreg} = variable gets Z register value.
+               {\bf zreg} variable gets Z register value.
 
-               {\bf sreg} = variable gets status register value.
+               {\bf sreg} variable gets status register value.
 
                  The {\bf SYS} command uses the current bank
                  as set with the {\bf BANK} command.
@@ -8743,7 +8744,7 @@ RUN
 \item [Format:] {\bf TEMPO speed}
 \item [Usage:] Sets the playback speed for the {\bf PLAY} command.
 
-               {\bf speed} = 1 -> 255.
+               {\bf speed} 1-255.
 
                The duration of a whole note is computed with
                $ duration = 24 / speed $.
@@ -8777,7 +8778,7 @@ RUN
 
                {\bf expression} is a logical or numeric expression.
                A numerical expression is evaluated as {\bf FALSE}
-               if the value is zero and {\bf TRUE} for any non zero
+               if the value is zero and {\bf TRUE} for any non-zero
                value.
 
                {\bf true clause} are one or more statements starting
@@ -8823,7 +8824,7 @@ RUN
 \index{TI}
 \index{BASIC 65 System Variables!TI}
 \begin{description}[leftmargin=2cm,style=nextline]
-\item [Format:] {\bf TI} is a reserved system variable
+\item [Format:] {\bf TI} is a reserved system variable.
 \item [Usage:]  {\bf TI} is a high precision timer with
                 the unit seconds and the
                 resolution of 1 micro second.
@@ -8853,7 +8854,7 @@ RUN
 \index{TI\$}
 \index{BASIC 65 System Variables!TI\$}
 \begin{description}[leftmargin=2cm,style=nextline]
-\item [Format:] {\bf TI\$} is a reserved system variable
+\item [Format:] {\bf TI\$} is a reserved system variable.
 \item [Usage:]  {\bf TI\$} holds the time information of the RTC
                 (Real Time Clock)
                 in text form of the format:
@@ -9364,7 +9365,7 @@ A$="###,###,###.#":PRINT USING A$;1E8/3
 \item [Usage:] Sets the volume for sound output with
                {\bf SOUND} or {\bf PLAY}.
 
-               {\bf volume} = 0 (off) -> 15 (loudest).
+               {\bf volume} 0 (off) -> 15 (loudest).
 
 \item [Remarks:] This volume setting affects all voices.
 
@@ -9395,12 +9396,12 @@ A$="###,###,###.#":PRINT USING A$;1E8/3
 \item [Usage:] Pauses the BASIC program until a requested
                bit pattern is read from the given address.
 
-               {\bf address} = the address at the current memory
+               {\bf address} the address at the current memory
                bank, which is read.
 
-               {\bf andmask} = and mask applied.
+               {\bf andmask} and mask applied.
 
-               {\bf xormask} = xor mask applied.
+               {\bf xormask} xor mask applied.
 
                {\bf WAIT} reads the byte value from {\bf address}
                and applies the masks: \\
@@ -9487,13 +9488,13 @@ A$="###,###,###.#":PRINT USING A$;1E8/3
 
                  {\bf left} = left column
 
-                 {\bf top} = top row
+                 {\bf top} top row
 
-                 {\bf right} = right column
+                 {\bf right} right column
 
-                 {\bf bottom} = bottom row
+                 {\bf bottom} bottom row
 
-                 {\bf clear} = clear text window flag
+                 {\bf clear} clear text window flag
 
                  The row values count from 0 to 24.
 


### PR DESCRIPTION
I removed the `=` characters when describing function parameters to be more inline with the c64 use manual and proof read from ~2500 - 3200.

Sorry for the mish-mash of fixes. I'll try not to mix them in future.