### PR TITLE
reuse wide parameter dir listing

### DIFF
--- a/appendix-basic65.tex
+++ b/appendix-basic65.tex
@@ -1088,6 +1088,7 @@ CATALOG "*,T=S"
 \end{tcolorbox}
 
 Below is an example showing how a directory looks with the {\bf w}ide parameter:
+\label{3columndirlisting}
 
 \begin{tcolorbox}[colback=black,coltext=white]
 \verbatimfont{\codefont}
@@ -2234,45 +2235,8 @@ DIR
 \end{verbatim}
 \end{tcolorbox}
 
-\begin{tcolorbox}[colback=black,coltext=white]
-\verbatimfont{\codefont}
-\begin{verbatim}
-DIR W
-\end{verbatim}
-% \selectfont{\codefont 0}
-\begin{tcolorbox}[colback=white,coltext=black,arc=0mm,boxrule=0mm,
-       left*=0.5mm,right*=0mm,top=0mm,bottom=0mm,nobeforeafter,
-       left skip=0.5mm,
-       width=28mm,height=3mm,valign=center]
-\begin{verbatim}
-   0 "BASIC EXAMPLES  "
-\end{verbatim}
-\end{tcolorbox}
-\begin{verbatim}
-   1 "BEGIN"            P     1 "FREAD"            P     2 "PAINT.COR"        P
-   1 "BEND"             P     1 "FRE"              P     3 "PALETTE.COR"      P
-   1 "BUMP"             P     2 "GET#"             P     1 "PEEK"             P
-   1 "CHAR"             P     1 "GETKEY"           P     3 "PEN"              P
-   1 "CHR$"             P     1 "GET"              P     1 "PLAY"             P
-   4 "CIRCLE"           P     2 "GOSUB"            P     2 "POINTER"          P
-   1 "CLOSE"            P     2 "GOTO.COR"         P     1 "POKE"             P
-   1 "CLR"              P     2 "GRAPHIC"          P     1 "POS"              P
-   2 "COLLISION"        P     1 "HELP"             P     1 "POT"              P
-   1 "CURSOR"           P     1 "IF"               P     1 "PRINT#"           P
-   0 "DATA BASE"        R     2 "INPUT#"           P     1 "PRINT"            P
-   1 "DATA"             P     2 "INPUT"            P     1 "RCOLOR.COR"       P
-   1 "DEF FN"           P     2 "JOY"              P     1 "READ"             P
-   1 "DIM"              P     1 "LINE INPUT#"      P     1 "RECORD"           P
-   1 "DO"               P     3 "LINE"             P     1 "REM"              P
-   5 "ELLIPSE"          P     1 "LOOP"             P     1 "RESTORE"          P
-   1 "ELSE"             P     1 "MID$"             P     1 "RESUME"           P
-   1 "EL"               P     1 "MOD"              P     1 "RETURN"           P
-   1 "ENVELOPE"         P     1 "MOVSPR"           P     1 "REVERS"           S
-   2 "EXIT"             P     1 "NEXT"             P     3 "RGRAPHIC"         P
-   1 "FOR"              P     2 "ON"               P     1 "RMOUSE"           P
-\end{verbatim}
-\end{tcolorbox}
-
+For a {\bf DIR} listing with the {\bf w}ide parameter, please refer to the example under the {\bf CATALOG} command
+on page \pageref{3columndirlisting}.
 %\includegraphics[width=\linewidth]{images/directory.png}
 
 \end{description}


### PR DESCRIPTION
This small change reuses a dir listing in the CATALOG command. Now the DIR command refers to it instead of duplicating it, saving just over half a page.