### PR TITLE
Update appendix-memorymap.tex

### DIFF
--- a/appendix-memorymap.tex
+++ b/appendix-memorymap.tex
@@ -16,7 +16,7 @@ programmer wishes to do so.  This means that while we frequently talk
 about ``C64 Mode,'' ``C65 Mode'' and ``MEGA65 Mode,'' these are simply
 terms of convenience for the MEGA65 with its memory map (and sometimes
 other features) configured to provide an environment that matches
-the appropriate mode.  The heart of this is the MEGA65's flexibly
+the appropriate mode.  The heart of this is the MEGA65's flexible
 memory map.
 
 In this appendix, we will begin by describing the MEGA65's native


### PR DESCRIPTION
Changed a possible typo. "the MEGA65’s flexibly memory map." to "the MEGA65’s flexible memory map."