### PR TITLE
MemoryMap: Fix $D000-$DFFF IO Personalities table last footer cutoff

### DIFF
--- a/appendix-memorymap.tex
+++ b/appendix-memorymap.tex
@@ -272,6 +272,13 @@ select the IO personality.
 \endhead
 \multicolumn{3}{l@{}}{continued \ldots}\\
 \endfoot
+\multicolumn{5}{p{10.2cm}}{{$^1$} In the C64 IO personality, \$D030 behaves as on C128, allowing toggling
+  between 1MHz and 2MHz CPU speed.}\\
+\multicolumn{5}{p{10.2cm}}{{$^2$} The additional MEGA65 SIDs are visible in
+  all IO personalities.}\\
+\multicolumn{5}{p{10.2cm}}{{$^3$} Some models may replace the repeated images
+  of the first four SIDs with four additional SIDs, for a total of 8 SIDs.}\\
+\endlastfoot
 \hline
 \small KEY & \small \$00 & \$A5, \$96 & \$45, \$54  & \$47, \$53 \\
 \hline
@@ -335,13 +342,6 @@ Registers & HyperTrap Registers \\
 \hline
 \small \$DE00 -- \$DFFF & \small CART IO & CART IO & ETHERNET Buffer & CART IO / SD SECTOR \\
 \hline
-\multicolumn{5}{p{10.2cm}}{{$^1$} In the C64 IO personality, \$D030 behaves as on C128, allowing toggling
-  between 1MHz and 2MHz CPU speed.}\\
-\multicolumn{5}{p{10.2cm}}{{$^2$} The additional MEGA65 SIDs are visible in
-  all IO personalities.}\\
-\multicolumn{5}{p{10.2cm}}{{$^3$} Some models may replace the repeated images
-  of the first four SIDs with four additional SIDs, for a total of 8 SIDs.}\\
-\endlastfoot
 \end{longtable}
 
 \section{CPU Memory Banking}


### PR DESCRIPTION
The way I understand it, \endlastfoot's need to be at the start of the
table.  The footnotes were dropping below the end of the page and were
unreadable in the PDF.  Also there was an empty header on a page by
itself.