### PR TITLE
Use longtable to avoid overflow on supports list pages

### DIFF
--- a/appendix-donors.tex
+++ b/appendix-donors.tex
@@ -62,7 +62,7 @@ Manual proof-reading               & \\
 \begin{small}
 % page 1
 \setlength{\tabcolsep}{1mm}
-\begin{tabular}{p{4cm}p{4cm}p{4cm}}
+\begin{longtable}{p{4cm}p{4cm}p{4cm}}
 @11110110100 & Arne Neumann & Christian Gräfe \\
 3c74ce64 & Arne Richard Tyarks & Christian Heffner \\
 8-Bit Classics & Axel Klahr & Christian Kersting \\
@@ -106,11 +106,6 @@ Arkadiusz Bronowicki & Chris Stringer & Dean Scully \\
 Arkadiusz Kwasny & Christian Boettcher & Dennis Jeschke \\
 Arnaud Léandre & Christian Eick & Dennis Schaffers \\
 Arne Drews & Christian Gleinser & Dennis Schierholz \\
-\end{tabular}
-% page 2
-\newpage
-\setlength{\tabcolsep}{1mm}
-\begin{tabular}{p{4cm}p{4cm}p{4cm}}
 Dennis Schneck & Frank Haaland & Hendrik Fensch \\
 denti & Frank Hempel & Henning Harperath \\
 Dick van Ginkel & Frank Koschel & Henri Parfait \\
@@ -157,11 +152,6 @@ Francesco Baldassarri & Heath Gallimore & Jeffrey van der Schilden \\
 Frank Fechner & Heinz Roesner & Jens Schneider \\
 Frank Glaush & Heinz Stampfli & Jens-Uwe Wessling \\
 Frank Gulasch & Helge Förster & Jesse DiSimone \\
-\end{tabular}
-% page 3
-\newpage
-\setlength{\tabcolsep}{1mm}
-\begin{tabular}{p{4cm}p{4cm}p{4cm}}
 Jett Adams & Kevin Thomasson & Marco van de Water \\
 Johan Arneklev & Kim Jorgensen & Marcus Gerards \\
 Johan Berntsson & Kim Rene Jensen & Marcus Herbert \\
@@ -208,11 +198,6 @@ Keith McComb & Marcel Kante & Matthew Carnevale \\
 Kenneth Dyke & Marco Beckers & Matthew Palmer \\
 Kenneth Joensson & Marco Cappellari & Matthew Santos \\
 Kevin Edwards & Marco Rivela & Matthias Barthel \\
-\end{tabular}
-% page 4
-\newpage
-\setlength{\tabcolsep}{1mm}
-\begin{tabular}{p{4cm}p{4cm}p{4cm}}
 Matthias Dolenc & Mike Betz & Paul Massay \\
 Matthias Fischer & Mike Kastrantas & Paul Westlake \\
 Matthias Frey & Mike Pikowski & Paul Woegerer \\
@@ -259,11 +244,6 @@ Michele Perini & Paul Gerhardt (KONG) & Riccardo Bianchi \\
 Michele Porcu & Paul Jackson & Richard Englert \\
 Miguel Angel Rodriguez Jodar & Paul Johnson & Richard Good \\
 Mikael Lund & Paul Kuhnast (mindrail) & Richard Menedetter \\
-\end{tabular}
-% page 5
-\newpage
-\setlength{\tabcolsep}{1mm}
-\begin{tabular}{p{4cm}p{4cm}p{4cm}}
 Richard Sopuch & Simon Lawrence & Thomas Scheelen \\
 Rick Reynolds & Simon Wolf & Thomas Schilling \\
 Rico Gruninger & spreen.digital & Thomas Tahsin-Bey \\
@@ -309,5 +289,5 @@ Shawn McKee & Thomas Karlsen & Yan B \\
 Siegfried Hartmann & Thomas Laskowski & Zoltan Markus \\
 Sigurbjorn Larusson & Thomas Marschall & Zsolt Zsila \\
 Sigurdur Finnsson & Thomas Niemann & Zytex Online Store \\
-\end{tabular}
+\end{longtable}
 \end{small}


### PR DESCRIPTION
The names were going past the bottom of the pages. 
Before:
<img width="794" alt="Screen Shot 2021-10-07 at 9 19 58 AM" src="https://user-images.githubusercontent.com/12048/136403654-c80cb9da-3ece-4d17-9e5c-814245b7fb05.png">

After:
<img width="794" alt="Screen Shot 2021-10-07 at 9 20 06 AM" src="https://user-images.githubusercontent.com/12048/136403755-2cbbb147-fe78-4edf-a28e-71a5846513c6.png">

