### PR TITLE
removed comma that breaks code in examples

### DIFF
--- a/modes.tex
+++ b/modes.tex
@@ -287,7 +287,7 @@ You can then put something else on the screen, and copy it back with:
 \begin{tcolorbox}[colback=black,coltext=white]
 \verbatimfont{\codefont}
 \begin{verbatim}
-DMA 0, 2000, 0, 4, 2048, 0, : REM SCREEN TEXT FROM BANK 4
+DMA 0, 2000, 0, 4, 2048, 0 : REM SCREEN TEXT FROM BANK 4
 DMA 0, 2000, 2000, 4, DEC("F800"), 1 : REM COPY COLOUR RAM FROM BANK 4
 \end{verbatim}
 \end{tcolorbox}


### PR DESCRIPTION
I tested the code and it wouldn't run. Removed the end comma and appears to function as intended.
(change had been reverted)