### PR TITLE
Use o with umlaut for name

### DIFF
--- a/appendix-donors.tex
+++ b/appendix-donors.tex
@@ -216,7 +216,7 @@ Kevin Edwards & Marco Rivela & Matthias Barthel \\
 Matthias Dolenc & Mikael Lund & Paul Kuhnast (mindrail) \\
 Matthias Fischer & Mike Betz & Paul Massay \\
 Matthias Frey & Mike Kastrantas & Paul Westlake \\
-Matthias Grandis & Mike Pikowski & Paul Woegerer \\
+Matthias Grandis & Mike Pikowski & Paul Wögerer \\
 Matthias Guth & Mikko Hämäläinen & Pauline Brasch \\
 Matthias Lampe & Mikko Suontausta & Paulo Apolonia \\
 Matthias Meier & Mirko Roller & Pete Collin \\


### PR DESCRIPTION
I have seen that others are also using umlauts in their names.

Please update my name as well to use `ö` instead of `oe`.