### PR TITLE
Mentioning of Matrix Mode Debugger should refer to MEGA65 Book

### DIFF
--- a/gettingstarted.tex
+++ b/gettingstarted.tex
@@ -40,7 +40,7 @@ There are some examples of this in \bookvref{sec:screen-editor}, and all of the 
 
 If a program is being LISTed to the screen, holding down \specialkey{CTRL} slows down the display of each line.
 
-Holding \specialkey{CTRL} and pressing \megakey{*} enters the Matrix Mode Debugger.
+Holding \specialkey{CTRL} and pressing \megakey{*} enters the Matrix Mode Debugger. Usage information is available in the MEGA65 Book.
 
 \subsubsection{RUN STOP}
 
@@ -95,7 +95,7 @@ Holding \megasymbolkey and pressing any key that shows a single graphic symbol o
 
 Holding \megasymbolkey and pressing a number key switches to one of the colours in the second range, i.e., the colour that is printed at the bottom row on the front of the number key will be used.
 
-Holding \megasymbolkey and pressing \specialkey{TAB} enters the Matrix Mode Debugger.
+Holding \megasymbolkey and pressing \specialkey{TAB} enters the Matrix Mode Debugger. Usage information is available in the MEGA65 Book.
 
 Switching on the MEGA65 or pressing the reset button on the left-hand side while holding down \megasymbolkey switches the MEGA65 into C64-mode.
 


### PR DESCRIPTION
As the Basic `MONITOR` command refers to the MEGA65 Book for more info,
the places that mention the Matrix Mode Debugger should do the same.