### PR TITLE
Standardised use of fixed-width and screentext usage on chapters 1-6

### DIFF
--- a/configuring.tex
+++ b/configuring.tex
@@ -44,7 +44,7 @@ switch between MEGA65 programs and games.
 
 Formatting an SD card on the MEGA65 is easy.
 
-Switch the MEGA65 on while holding down the \specialkey{ALT} key.
+Switch the MEGA65 on while pressing \specialkey{ALT}.
 
 This will present the MEGA65 Utility Menu, which contains a
 selection of built-in utilities, similar to the following:
@@ -55,12 +55,13 @@ selection of built-in utilities, similar to the following:
 \end{center}
 %\end{wrapfigure}
 
-{\em Note that Utility Menu is always accessible, even if no SD card is present in both the internal and external slots.}
+{\em Note that the Utility Menu is always accessible, even if no SD card is present in both the internal and external slots.}
 
 The exact set of utilities
 depends on the model of your MEGA65 and the version of the MEGA65
 factory core which it is running. However, all versions include both
-the MEGA65 FDISK/FORMAT utility, and the MEGA65 Configure utility.
+the MEGA65 FDISK/FORMAT utility (which is called \screentext{SDCARD FDISK+FORMAT UTILITY} in the screenshot above),
+and the MEGA65 Configure utility.
 Most models also include a keyboard test utility, that you can use
 to test that your keyboard is functioning correctly.  This is
 the same utility used in the factory when testing brand
@@ -108,7 +109,7 @@ Once you have selected the bus, the FDISK/FORMAT utility will ask you to confirm
 
 To avoid accidental loss of data, you must type \screentext{DELETE EVERYTHING} in capitals and press \specialkey{RETURN}. Alternatively, switch the MEGA65 off and on to abort this process without causing damage to your data.
 
-It is also possible to attempt a recovery from a lost Master Boot Record error (``Boot Sector'') by typing \screentext{FIX MBR} instead.
+It is also possible to attempt a recovery from a lost Master Boot Record error (also known as the Boot Sector) by typing \screentext{FIX MBR} instead.
 
 The aim here is to have a correctly formatted SD card with all of the essential files stored on it so the MEGA65 can properly boot.
 When switching on, the MEGA65 will search for, and boot using these files:
@@ -118,7 +119,7 @@ When switching on, the MEGA65 will search for, and boot using these files:
 \item {\tt C64THUMB.M65} (C64 thumbnail image used in freezer)
 \item {\tt C65THUMB.M65} (C65 thumbnail image used in freezer)
 \item {\tt MEGA65.ROM}   (128KB ROM file)
-\item {\tt MEGA65.D81 (default disk image, automatically mounted)}
+\item {\tt MEGA65.D81} (Disk image)
 \end{itemize}
 
 Straight out of the box, the MEGA65 will only have one SD card installed, accessible via the trap-door under the case. This SD card contains all of the essential files needed to properly boot up.
@@ -135,7 +136,7 @@ In general, if your MEGA65 cannot boot properly and falls back to OpenROM, your 
 \label{sec:installingrometc}
 
 The MEGA65 FDISK/FORMAT utility will add a copy of the Open ROMs project's C64-compatible ROM
-to your SD card, and will name it MEGA65.ROM.
+to your SD card, and will name it {\tt MEGA65.ROM}.
 
 For MEGA65 owners, we have replaced this file with the latest ROM from the 'Closed ROMs'
 project. It provides many improvements over the original/incomplete C65 ROMs. It contains
@@ -146,19 +147,19 @@ identified by the version number 92xxxx.
 However, you may have other ROMs that you wish to
 use on your MEGA65.
 You can copy as many of these as you wish onto the
-SD card, just make sure that they have the .ROM file extension.  The default ROM
-should be called MEGA65.ROM. These files
+SD card, just make sure that they have the {\tt .ROM} file extension.  The default ROM
+should be called "{\tt MEGA65.ROM}". These files
 must be 128KB in size, and use the same internal format as the ROMs
 intended for the C65.  This means that the C64-mode KERNAL must be
 placed at offset \$E000, a C65-mode BASIC at \$A000, and a suitable
 character set at \$D000.
 
-You can optionally name your alternate ROMs as 'MEGA65x.ROM', replacing 'x' with a number from 0 to 9.
+You can optionally name your alternate ROMs as {\tt MEGA65x.ROM}, replacing {\tt x} with a number from 0 to 9.
 This allows you to quickly boot-up to your alternate ROMs by holding down a number from \megakey{0} to \megakey{9} prior
 to switching on your MEGA65.
 
-Other important support files include FREEZER.M65 and AUDIOMIX.M65, which
-allow you to use the MEGA65's integrated freezer. More details are provided in the
+Other important support files include {\tt FREEZER.M65} and {\tt AUDIOMIX.M65}, which
+allow you to use the MEGA65's integrated Freezer. More details are provided in the
 'Floppy Disks, D81 Images, and the Freezer' chapter on page \pageref{cha:freezer}.
 
 \subsection{ROM File}
@@ -173,17 +174,15 @@ due to Commodore abandoning the C65 project.
 
 \textbf{MEGA65 Closed ROMs}
 
-There are also newer versions of the \textbf{MEGA65 Closed ROM} actively under development. These ROMs improve upon the original C65 ROMs and make better use of the extra hardware capabilities that the MEGA65 has over the original C65 hardware. These ROMs are available via the filehost (at \url{https://files.mega65.org}), but only to owners of the MEGA65, who will need to log into the filehost with their credentials in order to download it. It can be located by visiting the "\textbf{Files}" tab and searching for "\textbf{kernal rom}":
+There are also newer versions of the \textbf{MEGA65 Closed ROM} actively under development. These ROMs improve upon the original C65 ROMs and make better use of the extra hardware capabilities that the MEGA65 has over the original C65 hardware. These ROMs are available via the filehost (\url{https://files.mega65.org}), but only to owners of the MEGA65, who will need to login to the filehost with their credentials in order to download it. It can be located by visiting the \textbf{File} tab and searching for "\textbf{kernal rom}":
 
 \includegraphics[width=\linewidth]{images/latest_closed_rom.png}
 
 \textbf{MEGA65 ROM diff files}
 
-If you have sourced your own 911001.bin C65 ROM and would like to patch it to the latest MEGA65 closed ROM,
+If you have sourced your own {\tt 911001.bin} C65 ROM and would like to patch it to the latest MEGA65 closed ROM,
 we do provide patches, as the additional improvements we have made to the closed rom are open source.
-Those diff files are available here:
-
-\url{http://mega65.org/rom-diffs}
+These diff files are available at \url{http://mega65.org/rom-diffs}
 
 \textbf{MEGA65 Open ROMs}
 
@@ -197,19 +196,19 @@ Another available option is to make use of \textbf{MEGA65 Open ROMs}. The latest
 
 \subsection{Support Files}
 
-For official owners of the MEGA65 (both the devkit and the final product), visit the following url and log in with the user credentials you have been provided. This will take you to the MEGA65 Filehost location where the "\textbf{MEGA65 SD card essentials}" download page is located. Then click the "\textbf{Download}" link to retrieve the latest "\textbf{SD essentials.rar}" file.
+For official owners of the MEGA65 (both the devkit and the final product), visit the following url and log in with the user credentials you have been provided. This will take you to the MEGA65 Filehost location where the \textbf{MEGA65 SD card essentials} download page is located. Then click the \textbf{Download} link to retrieve the latest \textbf{SD essentials.rar} file.
 
 \url{http://mega65.org/sdcard-files}
 
 \includegraphics[width=\linewidth]{images/latest_support_files_with_closedrom.png}
 
-Note that this link is only available to official owners of the MEGA65 product, as the fileset also contains the licensed closed-source MEGA65.ROM file.
+Note that this link is only available to official owners of the MEGA65 product, as the fileset also contains the licensed closed-source {\tt MEGA65.ROM} file.
+\ifdefined\printmanual
+\else
+For Nexys board owners in search of a similar fileset (without the ROM), visit the following url instead: \url{http://mega65.org/sdcard-norom}
+\fi
 
-For Nexys board owners in search of a similar fileset (without the ROM), visit the following url instead:
-
-\url{http://mega65.org/sdcard-norom}
-
-This will take you to the MEGA65 Filehost location where the "\textbf{MEGA65 SD card essentials - No ROM}" download page is located. Click the "\textbf{Download}" link to retrieve the latest "\textbf{SD essentialsNoROM.rar}" file.
+This will take you to the MEGA65 Filehost location where the \textbf{MEGA65 SD card essentials - No ROM} download page is located. Click the \textbf{Download} link to retrieve the latest \textbf{SD essentialsNoROM.rar} file.
 
 Note that while this fileset does not contain a ROM, there are future plans for it to include the freely available ROM from the Open ROMs project.
 
@@ -270,7 +269,7 @@ The configuration utility for the MEGA65 has a similar purpose to the BIOS on a 
 battery-backed RAM, the MEGA65 stores this data on sector 1 of the SD card. If you switch SD cards, you will change the configuration data.
 
   To enter the configuration utility, switch the MEGA65 on while
-  holding \specialkey{ALT} down.  This will show the utility menu,
+  pressing \specialkey{ALT}.  This will show the utility menu,
   similar to the following:
 
 \begin{center}
@@ -289,9 +288,9 @@ battery-backed RAM, the MEGA65 stores this data on sector 1 of the SD card. If y
 %\end{minipage}
 
 %\begin{minipage}{\linewidth}
-  If your MEGA65's System Partition has become corrupt, you may be
-  prompted to press \megakey{F14} to correct this, i.e., hold \specialkey{SHIFT} and tap
-  the \megakey{F13} key, with a display similar to the following:
+  If your MEGA65's System Partition is corrupted, you may be
+  prompted to press \megakey{F14} to correct this, (i.e., hold \specialkey{SHIFT} and press
+  \megakey{F13}), with a display similar to the following:
 
 %  \vspace{5mm}
 \begin{center}
@@ -299,14 +298,14 @@ battery-backed RAM, the MEGA65 stores this data on sector 1 of the SD card. If y
 \end{center}
 %\end{minipage}
 
-To correct this error, press \megakey{F13}. Next, press \megakey{F7} to save the reset configuration, otherwise the reset data will not be saved to the MEGA65 System
+To correct this error, press \megakey{F14}. Next, press \megakey{F7} to save the reset configuration, otherwise the reset data will not be saved to the MEGA65 System
 Partition.
 
-Once you have dismissed that display, or if your MEGA65 System Partition was not corrupted, you can begin exploring and adjusting various settings. The program can be controlled using the keyboard, or optionally, an Amiga\texttrademark or C1351 mouse.
+Once you have dismissed that display, or if your MEGA65 System Partition is not corrupt, you can begin exploring and adjusting various settings. The program can be controlled using the keyboard, or optionally, an Amiga\texttrademark or 1351 mouse.
 
-You can advance screens by pressing \megakey{F1}, or use \megakey{F2} to navigate in the opposite direction. Use the \megakey{$\leftarrow$} and \megakey{$\rightarrow$} keys to navigate between screens.
+You can advance screens by pressing \megakey{F1}, or use \megakey{F2} to navigate in the opposite direction. Use \megakey{$\leftarrow$} and \megakey{$\rightarrow$} to navigate between screens.
 
-Use the \megakey{$\uparrow$} and \megakey{$\downarrow$} keys to select an item.
+Use \megakey{$\uparrow$} and \megakey{$\downarrow$} to select an item.
 
 Press \specialkey{RETURN} or \megakey{SPACE} to toggle a setting, or to change a text or numeric value. The black circle next to an option indicates the current selection.
 
@@ -318,10 +317,10 @@ Press \specialkey{RETURN} or \megakey{SPACE} to toggle a setting, or to change a
 \end{center}
 
 \begin{itemize}
-  \item{\em Exit Without Saving} abandons any changes made in the MEGA65 Configure utility and exits.
-  \item{\em Apply and Test Settings Now} uses the current settings immediately but does not exit. This is helpful to test compatibility of your TV or monitor with PAL or NTSC video modes. If you still see your display after applying a change, it is safe to save those settings.
-  \item{\em Restore Factory Defaults} resets the MEGA65 configuration settings to the factory defaults. It will randomly select a new MAC address for models that include an internal Ethernet adaptor. If you wish to commit these changes, you must still save them.
-  \item{\em Save as Default and Exit} commits changes made to the SD card. These changes will be used when the MEGA65 is switched on.
+  \item \screentext {EXIT WITHOUT SAVING} abandons any changes made in the MEGA65 Configure utility and exits.
+  \item \screentext {APPLY AND TEST SETTINGS NOW} uses the current settings immediately but does not exit. This is helpful to test compatibility of your TV or monitor with PAL or NTSC video modes. If you still see your display after applying a change, it is safe to save those settings.
+  \item \screentext {RESTORE FACTORY DEFAULTS} resets the MEGA65 configuration settings to the factory defaults. It will randomly select a new MAC address for models that include an internal Ethernet adaptor. If you wish to commit these changes, you must still save them.
+  \item \screentext {SAVE AS DEFAULT AND EXIT} commits changes made to the SD card. These changes will be used when the MEGA65 is switched on.
 \end{itemize}
 
 \subsection{Input Devices}
@@ -331,11 +330,11 @@ Press \specialkey{RETURN} or \megakey{SPACE} to toggle a setting, or to change a
 \end{center}
 
 \begin{itemize}
-  \item{\em Joystick 1 Amiga Mouse Mode} allows either {\bf normal} operation,
-  where software will see it as an Amiga mouse or {\bf 1351 emulation} mode, where the MEGA65 translates the Amiga mouse's movements into 1351 compatible  signals. This allows you to use an Amiga mouse with existing C64/C65 software compatible with a 1351 mouse.
-  \item{\em Joystick 1 Amiga Mouse Detection} can be set to conservative or aggressive. If you use an Amiga mouse and it fails to move smoothly in all directions, you may set it to {\bf aggressive}. Conversely, if you regularly use joysticks in the port, and have difficulties with the joystick input misbehaving, you may select the {\bf conservative} option.
-  \item{\em Joystick 2 Amiga Mouse Mode} is identical to the first option, but for the second joystick port. This allows you to have different settings for each port.
-  \item{\em Joystick 2 Amiga Mouse Detection} similarly provides the ability to separately control the Amiga mouse detection algorithm for the second joystick port.
+  \item \screentext{JOYSTICK 1 AMIGA MOUSE MODE} allows either \screentext{NORMAL} operation,
+  where software will see it as an Amiga mouse or \screentext{1351 EMULATION} mode, where the MEGA65 translates the Amiga mouse's movements into 1351 compatible signals. This allows you to use an Amiga mouse with existing C64/C65 software with a 1351 mouse.
+  \item \screentext{JOYSTICK 1 AMIGA MOUSE DETECTION} can be set to \screentext{CONSERVATIVE} or \screentext{AGGRESSIVE}. If you use an Amiga mouse and it fails to move smoothly in all directions, you may set it to \screentext{AGGRESSIVE}. Conversely, if you regularly use joysticks in the port, and have difficulties with the joystick input misbehaving, you might want to use the \screentext{CONSERVATIVE} option.
+  \item \screentext{JOYSTICK 2 AMIGA MOUSE MODE} is identical to the first option, but for the second controller port. This allows you to have different settings for each port.
+  \item \screentext{JOYSTICK 1 AMIGA MOUSE DETECTION} similarly provides the ability to separately control the Amiga mouse detection algorithm for the second controller port.
 \end{itemize}
 
 
@@ -346,28 +345,28 @@ Press \specialkey{RETURN} or \megakey{SPACE} to toggle a setting, or to change a
 \end{center}
 
 \begin{itemize}
-  \item{\em Real-Time Clock} allows setting the MEGA65's Real-Time
+  \item \screentext{REAL-TIME CLOCK} allows setting the MEGA65's Real-Time
     Clock for those models that include one.  To set the clock or
     calendar, simply edit the field and press \specialkey{RETURN}.
     The display does not change while viewing this page, but if
-    you use the cursor left and right keys to select another page and
+    you use \megakey{$\leftarrow$} and \megakey{$\rightarrow$} to select another page and
     return to this page, the values will update if a Real-Time Clock
     is fitted and functioning.
-  \item{\em DMAgic Revision} allows selecting the default mode of
+  \item \screentext{DMAGIC REVISION} allows selecting the default mode of
     operation for the C65 DMAgic DMA controller.  This option is only
     required for ROMs not detected by the MEGA65's HYPPO Hypervisor.
     If you see screen corruption in BASIC,
     try toggling this option.
-  \item{\em F011 Disk Controller}
+  \item \screentext{F011 DISK CONTROLLER}
     This option allows you to select whether the internal 3.5'' floppy
     drive functions using real diskettes, or whether it simply makes
     noises to add atmosphere when using D81 disk images from the SD
     card.  This merely sets the default option, and you can change
     this setting, or select a different disk image for use as either
     or both of the C65 3.5'' DOS based drives.
-  \item{\em Default Disk Image} allows you to choose the D81 disk image
-    used with the internal drive, if the F011 Disk
-    Controller option above is set to use an SD card disk image.
+  \item \screentext{DEFAULT DISK IMAGE} allows you to choose the D81 disk image
+    used with the internal drive, if the \screentext{F011 DISK CONTROLLER}
+    option above is set to \screentext{USES SDCARD DISK IMAGE}.
 \end{itemize}
 
 \subsection{Video}
@@ -377,7 +376,7 @@ Press \specialkey{RETURN} or \megakey{SPACE} to toggle a setting, or to change a
 \end{center}
 
 \begin{itemize}
-  \item{\em Video Mode} selects whether the MEGA65 starts in PAL or NTSC.    The MEGA65 supports true 480p NTSC and 576p PAL double-scan modes, with exact 60Hz / 50Hz frame-rates. This setting sets the default value, and the system can be switched between PAL and NTSC via the Freeze Menu, or under software control by MEGA65-enabled programs.
+  \item \screentext{VIDEO MODE} selects whether the MEGA65 starts in PAL or NTSC.    The MEGA65 supports true 480p NTSC and 576p PAL double-scan modes, with exact 60Hz / 50Hz frame-rates. This setting sets the default value, and the system can be switched between PAL and NTSC via the Freeze Menu, or under software control by MEGA65-enabled programs.
 \end{itemize}
 
 \subsection{Audio}
@@ -387,10 +386,10 @@ Press \specialkey{RETURN} or \megakey{SPACE} to toggle a setting, or to change a
 \end{center}
 
 \begin{itemize}
-  \item{\em Audio Output} selects whether the SIDs and digital audio channels are combined to provide a monaural signal or whether the left and right tagged audio sources are separated to provide a stereo signal. This setting can be changed in the Audio Mixer of the Freeze Menu, or under the control of MEGA65-enabled software.
-  \item{\em Swap Stereo Channels} allows switching the left and right-hand sides of the stereo audio output. This is useful for software that expects left and right SIDs to be at swapped addresses compared with the MEGA65 defaults.
-  \item{\em DAC Algorithm} allows selecting between two different digital to analog conversion algorithms. Both options sound good and the selection is a personal preference.
-  \item{\em Audio Amplifier} allows enabling or disabling the audio amplifier contained in some models of the MEGA65. This option works for audio outputs, e.g., internal speaker or loud speaker.
+  \item \screentext{AUDIO OUTPUT} selects whether the SIDs and digital audio channels are combined to provide a monaural signal or whether the left and right tagged audio sources are separated to provide a stereo signal. This setting can be changed in the Audio Mixer of the Freeze Menu, or under the control of MEGA65-enabled software.
+  \item \screentext{SWAP STEREO CHANNELS} allows switching the left and right-hand sides of the stereo audio output. This is useful for software that expects left and right SIDs to be at swapped addresses compared with the MEGA65 defaults.
+  \item \screentext{DAC ALGORITHM} allows selecting between two different digital to analog conversion algorithms. Both options sound good and the selection is a personal preference.
+  \item \screentext{AUDIO AMPLIFIER} allows enabling or disabling the audio amplifier contained in some models of the MEGA65. This option works for audio outputs, e.g., internal speaker or loud speaker.
 \end{itemize}
 
 \subsection{Network}
@@ -400,7 +399,5 @@ Press \specialkey{RETURN} or \megakey{SPACE} to toggle a setting, or to change a
 \end{center}
 
 \begin{itemize}
-  \item{\em MAC Address} allows you to set the default MAC address of your MEGA65. This can be changed at run-time by MEGA65-enabled software.
+  \item \screentext{MAC ADDRESS} allows you to set the default MAC address of your MEGA65. This can be changed at run-time by MEGA65-enabled software.
 \end{itemize}
-
-% 2021-03-17 edits by SBC

--- a/cores-and-flashing.tex
+++ b/cores-and-flashing.tex
@@ -84,13 +84,13 @@ order to decide what file-types are needed for what occasion.
     \hline
     {\textbf{File-type}} & {\textbf{Purpose}} \\
     \hline
-    {.cor} & {The MEGA65 project's custom bitstream file format, containing extra header information to help identify the bitstream and the specific MEGA65 target device it is intended for. The MEGA65's flashing utility makes use of this additional information to ensure you don't accidentally flash the bitstream of a different device.} \\
+    {\tt .cor} & {The MEGA65 project's custom bitstream file format, containing extra header information to help identify the bitstream and the specific MEGA65 target device it is intended for. The MEGA65's flashing utility makes use of this additional information to ensure you don't accidentally flash the bitstream of a different device.} \\
     \hline
-    {.mcs} & {The bitstream file in a format needed when flashing it to your device's QSPI flash memory chip via Vivado\textregistered.} \\
+    {\tt .mcs} & {The bitstream file in a format needed when flashing it to your device's QSPI flash memory chip via Vivado\textregistered.} \\
     \hline
-    {.prm} & {This file contains checksum information that can be used by Vivado to verify the .mcs file you have tried to flash. Optional.} \\
+    {\tt .prm} & {This file contains checksum information that can be used by Vivado to verify the .mcs file you have tried to flash. Optional.} \\
     \hline
-    {.bit} & {A plain bitstream file that can be copied to your SD card.} \\
+    {\tt .bit} & {A plain bitstream file that can be copied to your SD card.} \\
     \hline
   \end{longtable}
 \end{center}
@@ -103,7 +103,7 @@ Visit the following url:
 
 \includegraphics[width=\linewidth]{images/latest_bitstream.png}
 
-Click the 'Files' tab, and in the search-bar, type '.cor' and press Enter.
+Click the {\bf Files} tab, and in the search-bar, type {\bf .cor} and press Enter.
 \ifdefined\printmanual
   You will notice that there are different files with the {\bf .cor} extension. For your MEGA65, download the file
   that ends with {\bf 65r3-dev.cor}. Other files are for other device types, which you can read more about in the
@@ -157,7 +157,7 @@ will not reset which core is being run.
 \phantomsection
 \section{Installing an upgrade core for the MEGA65}
 
-Installing and upgrading the core (from a .cor file) for the MEGA65 can be done in a few easy steps.
+Installing and upgrading the core (from a {\tt .cor} file) for the MEGA65 can be done in a few easy steps.
 
 First, copy the core onto the MEGA65's SD card. You can do this by removing the SD card and copying a previously
 downloaded core file to it from another computer. Alternatively,
@@ -200,7 +200,7 @@ The progress bar will then reset, and the MEGA65 will
 write the new core into the slot. This process can take up to 15
 minutes, depending on the size of the core file.  If you simply wish
 to erase a flash slot, you can select the
-``-- erase slot --'' option instead of a file name. This will then perform
+\screentext{ -- erase slot --} option instead of a file name. This will then perform
 only the erasure part of the process.
 
 {\bf It is important to not switch the power off during this process}. If you do, the core file will be

--- a/freezer.tex
+++ b/freezer.tex
@@ -86,6 +86,7 @@ two floppy drives. However, both drives must be attached to the same ribbon cabl
 {\bf U} for UNIT and {\bf D} for drive, which use the default values of
 {\bf UNIT = 8}, and {\bf DRIVE = 0}.
 
+\label{sec:freezer}
 \section{The Freezer}
 The MEGA65 {\bf FREEZER} is a tool for changing system parameters at any time,
 regardless of the currently running program. It's very similar to the Freezer that many popular cartridges

--- a/gettingstarted.tex
+++ b/gettingstarted.tex
@@ -21,7 +21,7 @@ Pressing \specialkey{RETURN} enters the information you have typed into the MEGA
 
 The two \specialkey{SHIFT} keys are located on the left and the right. They work very much like the Shift key on a regular keyboard, however they also perform some special functions as well.
 
-In upper case mode, holding down \specialkey{SHIFT} and pressing any key with two graphic symbols on the front produces the right-hand symbol on that key. For example, \specialkey{SHIFT} and \megakey{J} prints the \graphicsymbol{J} character.
+In upper case mode, holding down \specialkey{SHIFT} and pressing any key with two graphic symbols on the front prints the right-most graphic symbol to the screen. For example, \specialkey{SHIFT} and \megakey{J} prints the \graphicsymbol{J} character.
 
 In lower case mode, pressing \specialkey{SHIFT} and a letter key prints the upper case letter on that key.
 
@@ -105,7 +105,7 @@ If a program is being LISTed to the screen, pressing \specialkey{NO\\SCROLL} fre
 
 \subsection{Function Keys}
 
-There are seven Function keys available for use by software applications, \megakey{F1} \megakey{F3} \megakey{F5} \megakey{F7} \megakey{F9} \megakey{F11} and \megakey{F13} can be used to perform specific functions with a single press.
+There are seven Function keys available for use by software applications. \megakey{F1} \megakey{F3} \megakey{F5} \megakey{F7} \megakey{F9} \megakey{F11} and \megakey{F13} can be used to perform specific functions with a single press.
 
 Hold \specialkey{SHIFT} to access \megakey{F2} through to \megakey{F14} as shown on the front of each Function key.
 

--- a/introduction.tex
+++ b/introduction.tex
@@ -13,9 +13,9 @@ This guide will teach you how to do more than just hang pictures on a wall, it w
 Computer graphics and music make computing more fun; and we designed the MEGA65 for fun! In this user's guide, you will learn how to program using the MEGA65's built-in {\bf graphics} and {\bf sound} capabilities. But you don't need to be a programmer to have fun with the MEGA65. Because the MEGA65 includes a complete Commodore{\textregistered} 64{\texttrademark}\footnote{Commodore 64 is a trademark of C= Holdings}, it can also run thousands of games, utilities, and business software packages from the past, as well as new programs being written today by Commodore computer enthusiasts. Excitement for the MEGA65 will grow as we discover what programmers create as they learn about the power and features of this modern Commodore computer recreation. Together, we will build a new ``homebrew'' community to create software and projects we didn't think were possible on the MEGA65.
 
 We welcome you on this journey! Thank you for becoming a part of the {\bf MEGA65}
-community of users, programmers, and enthusiasts! Get involved, learn more
-about your MEGA65, and join us online at:
+community of users, programmers, and enthusiasts!
 
+% Get involved, learn more about your MEGA65, and join us online at:
 % TODO - I thought a call to action to join the community would be good to add early on. Where will the final online community call home?
 
 \section{Other Books in this series}

--- a/screen-editor.tex
+++ b/screen-editor.tex
@@ -7,22 +7,23 @@ When you switch on your MEGA65 or reset it, the following screen will appear:
 \includegraphics[width={10cm}]{images/introduction-screen/layout.png}
 \end{center}
 
-The colour bars in the top left-hand side of the screen can be used
+The colour bars at the top left-hand side of the screen can be used
 as a guide to help calibrate the colours of your display.
 The screen also displays the name of the system,
 the copyright notice, and the ROM version.
 The displayed date and time are taken from the internal RTC
-(Real-Time Clock), which can be set in the Configure Menu.
+(Real-Time Clock), which can be set in the Configure Menu. You can
+read more about the Configure menu on page \pageref{sec:configuration-utility}.
 
-Finally, you will see the READY prompt and the flashing cursor.
+Finally, you will see the \screentext{READY} prompt and the flashing cursor.
 
 You can begin typing keys on the keyboard and the characters will be
 printed at the cursor position. The cursor itself will advance after
 each key press.
 
-You can also produce reverse text or colour bars by holding down \specialkey{CTRL} and pressing \megakey{9}, or \megakey{R}. This enters reverse text mode. When this is enabled, you can press and hold the \megakey{Space bar}. While doing so, a white bar will be drawn across the screen.
+You can also produce reverse text or colour bars by holding down \specialkey{CTRL} and pressing \megakey{9}, or \megakey{R}. This enters reverse text mode. When this is enabled, you can press and hold the \megakey{Space}. While doing so, a white bar will be drawn across the screen.
 
-You can even change the current colour by holding \specialkey{CTRL} down and pressing a number key (from \megakey{1} to \megakey{8}). For example, if you press and hold \specialkey{CTRL} down and press \megakey{1}, the colour will change to black. Now, when you hold down the \megakey{Space bar}, a black bar will be drawn. If you continue to change the colour and press the \megakey{Space bar}, you will get an effect similar to the image below:
+You can even change the current colour by holding \specialkey{CTRL} down and pressing a number key (from \megakey{1} to \megakey{8}). For example, if you press and hold \specialkey{CTRL} down and press \megakey{1}, the colour will change to black. Now, when you hold down the \megakey{Space}, a black bar will be drawn. If you continue to change the colour and press the \megakey{Space bar}, you will get an effect similar to the image below:
 
 
 \begin{center}
@@ -85,7 +86,7 @@ To find the complete set of Control codes, see \bookvref{appendix:controlcodes}.
 
 \textbf{Creating a Window}
 
-You can set a window on the MEGA65 working screen. Move your cursor to the beginning of the "BASIC 65" text. Press \specialkey{ESC}, then press \megakey{T}. Move the cursor 10 lines down and 15 to the right.
+You can set a window on the MEGA65 working screen. Move your cursor to the beginning of the \screentext{BASIC 65} text. Press \specialkey{ESC}, then press \megakey{T}. Move the cursor 10 lines down and 15 to the right.
 
 Press \specialkey{ESC}, then \megakey{B}. Anything you type will be contained within this window.
 
@@ -96,6 +97,6 @@ To escape from the window back to the full screen, press \specialkey{CLR HOME} t
 
 Long press on \widekey{RESTORE} to go into the Freeze Menu.  Then press \megakey{J} to switch joystick ports without having to physically swap the joystick to the other port.
 
-Go to \textbf{Fast mode} with \screentext{POKE 0,65} or use the Freeze Menu.
+Go to \textbf{Fast mode} with {\bf POKE 0,65} or use the Freezer. You can learn more about the Freezer on page \pageref{sec:freezer}.
 
 \megasymbolkey + \specialkey{SHIFT} switches between uppercase and lowercase text for the entire display.

--- a/style-guide.md
+++ b/style-guide.md
@@ -31,6 +31,11 @@ Below are some simple MEGA65 styling rules:
   appear in a particular way, remember to reset anything you have changed back to the default. These especially include
   `setlength`.  
 
+* Fonts. When referring to buttons, or elements of a webpage, you can highlight them with bold text. When referring 
+  to filenames that the MEGA65 uses (either on a disk or on an SD card), please use the fixed-width font using 
+ `{\tt <your text here}` syntax. If you're referring to a part of a MEGA65 screen (regardless if it's text in the 
+  editor or in a configuration screen), please use `\screentext{<your text here>}` syntax instead.
+
 * If you're stuck on when to use commas and hyphens refer to the 
   [Microsoft style guide](https://docs.microsoft.com/en-us/style-guide/punctuation/commas).
 


### PR DESCRIPTION
* Fonts. When referring to buttons, or elements of a webpage, you can highlight them with bold text. When referring 
  to filenames that the MEGA65 uses (either on a disk or on an SD card), please use the fixed-width font using 
 `{\tt <your text here}` syntax. If you're referring to a part of a MEGA65 screen (regardless if it's text in the 
  editor or in a configuration screen), please use `\screentext{<your text here>}` syntax instead.