### PR TITLE
remove slight ambiguity from configuring sd card

### DIFF
--- a/configuring.tex
+++ b/configuring.tex
@@ -22,8 +22,7 @@ If you have cards in both slots, the MEGA65 will default to the external slot. T
 utility can access both, allowing you to select which SD card to format or
 repair.
 
-Depending on the model, your MEGA65 may or may not have come with a pre-configured SD card. If it hasn't, or if you wish to use a different SD card,
-(e.g., with a larger capacity), you must format it for use in the MEGA65.
+If you wish to use a different SD card than the pre-configured one supplied with your MEGA65, the new SD card must be formatted first.
 
 {\em This must be done on the MEGA65, not on a PC or other computer.}
 


### PR DESCRIPTION
After a discord discussion it was noted that the IMPORTANT message does a good job of conveying that the MEGA65 comes with an SDCARD, but you may need to prepare a new one at times. But then the document said depending on the model you may or may not have received an sd card.
This is a proposed reword to not conflict with the original message that you DO receive an sdcard when you purchase the MEGA65.

I was unsure if the next statement about not doing it on a PC should be brought into this same paragraph or not. 

Please feel free to reformat or change as seen fit.