### PR TITLE
Simulate a section title for the BASIC 65 quick reference card.

### DIFF
--- a/backcover.tex
+++ b/backcover.tex
@@ -1,7 +1,9 @@
 \pagestyle{empty}
 \cleardoublepage
 \newpage\null\thispagestyle{empty}\newpage
-\section{BASIC 65 Quick Reference Card}
+{\raggedright\huge\bf\color{headingblue} BASIC 65 QUICK REFERENCE CARD}
+\vspace{17pt}
+\\*
 \includegraphics[width=\linewidth]{images/illustrations/basic65_quick_reference_card.pdf}
 \newpage
 \begin{tikzpicture}[remember picture,overlay,shift={(current page.north east)}]


### PR DESCRIPTION
Replace the `\section` on the BASIC 65 quick reference was the equivalent LaTeX coding.

This resolves the issue of the "lonely" section title appearing on the index cover page. It also removes it from the table of contents, where it was somewhat oddly appearing under INDEX.