### PR TITLE
Edits to command formats

### DIFF
--- a/appendix-basic65.tex
+++ b/appendix-basic65.tex
@@ -2135,7 +2135,8 @@ N-POINT GAUSSLEGENDRE FACTORS E1
 \index{BASIC 65 Commands!DCLOSE}
 \begin{description}[leftmargin=2cm,style=nextline]
 \item [Token:] \$FE \$0F
-\item [Format:] {\bf DCLOSE} [{\bf\#} channel] [{\bf,U} unit]
+\item [Format:] {\bf DCLOSE} [{\bf U} unit] \\
+		{\bf DCLOSE \#} channel
 \item [Usage:]
    Closes a single file or
    all files for the specified unit.


### PR DESCRIPTION
Following on from #372.
- Only use bold face around the parts of the command formats needing to be entered as written. This is keywords, and symbols that are not part of the meta-syntax.
- Introduce the new meta-syntax `{a, b, c}` for arguments that are optional but you need to keep the commas when you leave out the argument.
  - `{a, b, c}` is a similar to `[a] [,[b] [,[c]]]` except at least one of a, b or c is needed.
  - `[{a, b, c}]` is a equivalent to `[[a] [,[b] [,[c]]]]`.
- Add a meta-syntax summary table under the "BASIC command reference" heading.
- Additional changes and corrections to specific command formats.
  - Notably LOADIFF and SAVEIFF, which do use the D and U letters in front of the disk and unit arguments.