### PR TITLE
Removed Command Keys from TOC, made all sections title case

### DIFF
--- a/appendix-basic65.tex
+++ b/appendix-basic65.tex
@@ -111,8 +111,8 @@ prompt, or from within a program, for example:
 \end{tcolorbox}
 
 \newpage
-\section{BASIC 65 constants}
-
+\subsection{BASIC 65 Constants}
+\index{BASIC 65 Constants}
 {\ttfamily
 \setlength{\tabcolsep}{1mm}
 \begin{center}
@@ -130,7 +130,8 @@ string                  & "X"     & "TEXT"    \\
 \end{center}
 }
 
-\section{BASIC 65 variables}
+\subsection{BASIC 65 Variables}
+\index{BASIC 65 Variables}
 
 Each scalar variable consumes 8 bytes of storage in memory.
 The reserved area in bank 0 from \$F700-\$FEFF can store 256 variables.
@@ -155,7 +156,8 @@ string                  &    \$    & length = 0 .. 255 & AB\$ = "TEXT" \\
 \end{center}
 }
 
-\section{BASIC 65 arrays}
+\subsection{BASIC 65 Arrays}
+\index{BASIC 65 Arrays}
 
 Each array consumes the number of elements multiplied by the item size
 plus the size of the header (6 + 2 * dimensions) in memory.
@@ -208,7 +210,8 @@ string   array &  3     &    \$    & length = 0 .. 255 & AB\$(X) = "TEXT" \\
 \end{center}
 }
 
-\section{BASIC 65 operators}
+\subsection{BASIC 65 Operators}
+\index{BASIC 65 Operators}
 
 BASIC 65 provides a set of operators, that is typical for most BASIC
 programming languages. The usage and the precedence correspond to the standards.
@@ -258,7 +261,7 @@ both  multiplications will be done , before the subtraction is executed.
 Parentheses are used to change the precedence, for example
 \screentextwide{A * (A - B) * B)} will execute the subtraction first.
 
-\subsection{assignment operator}
+\subsection{Assignment Operator}
 
 {\ttfamily
 \setlength{\tabcolsep}{1mm}
@@ -273,7 +276,7 @@ symbol & description & operand type & example \\
 \end{center}
 }
 
-\subsection{unary mathematical operators}
+\subsection{Unary Nathematical Operators}
 
 {\ttfamily
 \setlength{\tabcolsep}{1mm}
@@ -289,7 +292,7 @@ minus & -   & negative sign & numerical & B = -42 \\
 \end{center}
 }
 
-\subsection{binary mathematical operators}
+\subsection{Binary Mathematical Operators}
 
 {\ttfamily
 \setlength{\tabcolsep}{1mm}
@@ -308,7 +311,7 @@ uparrow & $\uparrow$   & exponentiation & numerical & E = 2 $\uparrow$ 10\\
 \end{center}
 }
 
-\subsection{relational operators}
+\subsection{Relational Operators}
 
 {\ttfamily
 \setlength{\tabcolsep}{1mm}
@@ -328,7 +331,7 @@ symbol & description & operand type & example \\
 \end{center}
 }
 
-\subsection{logical operators}
+\subsection{Logical Operators}
 
 {\ttfamily
 \setlength{\tabcolsep}{1mm}
@@ -346,7 +349,7 @@ NOT  & negation         & logical & C = NOT A > B \\
 \end{center}
 }
 
-\subsection{boolean operators}
+\subsection{Boolean Operators}
 
 {\ttfamily
 \setlength{\tabcolsep}{1mm}
@@ -364,7 +367,7 @@ NOT  & negation         & boolean & A = NOT 22 \\
 \end{center}
 }
 
-\subsection{string operator}
+\subsection{String Operator}
 
 {\ttfamily
 \setlength{\tabcolsep}{1mm}
@@ -379,7 +382,7 @@ plus & + & concatenation    & string & A\$ = B\$ + ".PRG" \\
 \end{center}
 }
 
-\subsection{operator precedence}
+\subsection{Operator Precedence}
 
 {\ttfamily
 \setlength{\tabcolsep}{1mm}
@@ -404,7 +407,7 @@ low & OR XOR\\
 \input{appendix-keywords}
 
 \newpage
-\section{BASIC command reference}
+\section{BASIC Command Reference}
 
 \begin{center}
 \setlength{\def\arraystretch{1.5}\tabcolsep}{6pt}

--- a/cores-and-flashing.tex
+++ b/cores-and-flashing.tex
@@ -2,7 +2,7 @@
 \label{cha:cores}
 
 \phantomsection
-\section{What are cores, and why do they matter?}
+\section{What are Cores, and Why Do They Matter?}
 
 The MEGA65 computer uses a versatile chip called an FPGA as its heart, which is
 an acronym for ``Field Programmable Gate Array''. This is a fancy way of
@@ -78,7 +78,7 @@ order to decide what file-types are needed for what occasion.
 
 \subsection{File types}
 
-\index{.bit files}\index{.mcs files}\index{.prm files}\index{.cor files}
+%\index{.bit files}\index{.mcs files}\index{.prm files}\index{.cor files}
 \begin{center}
   \begin{longtable}{|L{1.5cm}|p{10cm}|}
     \hline
@@ -95,7 +95,7 @@ order to decide what file-types are needed for what occasion.
   \end{longtable}
 \end{center}
 
-\subsection{Where to download}
+\subsection{Where to Download}
 
 Visit the following url:
 
@@ -127,7 +127,7 @@ Click the {\bf Files} tab, and in the search-bar, type {\bf .cor} and press Ente
 \fi
 
 \phantomsection
-\section{Selecting a core}
+\section{Selecting a Core}
 
 To operate the MEGA65 with an alternate core, switch off the power to the MEGA65, and then hold
 \specialkey{NO SCROLL} down while switching the power back on. This instructs the MEGA65 to enter the
@@ -155,7 +155,7 @@ The MEGA65 will keep running the new core until you physically power it off.  Pr
 will not reset which core is being run.
 
 \phantomsection
-\section{Installing an upgrade core for the MEGA65}
+\section{Installing an Upgrade Core for the MEGA65}
 
 Installing and upgrading the core (from a {\tt .cor} file) for the MEGA65 can be done in a few easy steps.
 
@@ -224,7 +224,7 @@ upgraded core.  This is because the MEGA65 will always try to start the core in 
 it is switched on.
 
 \phantomsection
-\section{Installing other cores}
+\section{Installing Other Cores}
 
 Installing other cores works very similarly to installing upgrade cores. The only difference is that you
 press \specialkey{CTRL} and \megakey{2} to \megakey{7} from the Flash and Core Menu, so that the core
@@ -236,7 +236,7 @@ you can always choose to run the MEGA65 core by entering the Flash and Core Menu
 core.
 
 \phantomsection
-\section{Creating cores for the MEGA65}
+\section{Creating Cores for the MEGA65}
 
 If you would like to create your own cores for the MEGA65, or help
 contribute to the MEGA65 core, then
@@ -250,7 +250,7 @@ which explains how to use the
 FPGA development tools to flash the MEGA65.
 
 \phantomsection
-\section{Replacing the factory core in slot 0}
+\section{Replacing the Factory Core in Slot 0}
 
 Replacing the core in slot 0 is not recommended, because if it ever gets corrupted, it will ``brick'' the machine.
 This will require you to connect a TE-0790 JTAG programmer, by opening your MEGA65 case, installing

--- a/freezer.tex
+++ b/freezer.tex
@@ -209,7 +209,7 @@ try and find a disk, which could take a few seconds. Any previously mounted D81 
 these options.
 
 
-\subsection{Auto booting from a disk}
+\subsection{Auto Booting From a Disk}
 If you would like the MEGA65 to automatically perform any BASIC commands upon startup, you can create an
 {\bf AUTOBOOT.C65} PRG file on your disk/image. In this file, you can write BASIC programs to do things such
 as changing the {\bf BACKGROUND}, {\bf BORDER}, or {\bf FOREGROUND} colours, or even {\bf LOAD} a program.

--- a/gettingstarted.tex
+++ b/gettingstarted.tex
@@ -1,4 +1,6 @@
 \chapter{Getting Started}
+\addtocontents{toc}{\protect\setcounter{tocdepth}{2}}
+\hypersetup{bookmarksdepth=5}
 \phantomsection
 \section{Keyboard}
 \label{cha:getting-started}
@@ -142,3 +144,5 @@ Holding \specialkey{ALT} down while switching the MEGA65 on activates the Utilit
 Also, holding \specialkey{CAPS\\LOCK} down forces the processor to run at the maximum speed. This can be used for things such as
 speeding up loading from the internal disk drive or SD card, or to greatly speed up the de-packing process after a program is run.
 This can reduce the loading and de-packing time from many seconds to as little as a fraction of a second.
+
+\addtocontents{toc}{\protect\setcounter{tocdepth}{5}}

--- a/mega65-userguide.tex
+++ b/mega65-userguide.tex
@@ -36,7 +36,8 @@
   \vfill
   WORK IN PROGRESS
 
-  \index{copyright}Copyright \copyright 2019 -- 2021 by Paul Gardner-Stephen,
+  %\index{copyright}
+  Copyright \copyright 2019 -- 2021 by Paul Gardner-Stephen,
   the MEGA Museum of Electronic Games \& Art e.V.,
   and contributors.
 

--- a/modes.tex
+++ b/modes.tex
@@ -7,7 +7,7 @@ of these earlier computers.
 
 By default, the {\tt MEGA65.ROM} file boots to MEGA65-mode
 (including BASIC 65), and
-provides a method to switch to C64-mode via the {\bf GO 64} command.
+provides a method to switch to C64-mode via the \screentext{GO 64} command.
 However, it is also possible to use an original C65 ROM (version {\tt 91XXXX.BIN})
 renamed to {\tt MEGA65.ROM}, making the MEGA65 start in C65-mode
 with BASIC 10. This also provides the same functionality to switch to C64-mode.
@@ -19,8 +19,8 @@ Therefore, dependent on your boot ROM choice, you have:
  \hline
   {\textbf{Boot Mode}} & {\textbf{ROM version}} & {\textbf{BASIC}} & {\textbf{C64-mode}} \\
  \hline
-   MEGA65    & \screentext{92XXXX}      & BASIC 65 & {\bf GO 64} \\
-   C65       & \screentext{91XXXX}      & BASIC 10 & {\bf GO 64} \\
+   MEGA65    & \screentext{92XXXX}      & BASIC 65 & \screentext{GO 64} \\
+   C65       & \screentext{91XXXX}      & BASIC 10 & \screentext{GO 64} \\
  \hline
 \end{tabular}
 \end{center}
@@ -51,7 +51,7 @@ More information on how to write such programs can be found in the various appen
 
 \subsection{From MEGA65/C65 to C64-mode}
 
-To switch from MEGA65/C65 to C64-mode, use the familiar {\bf GO 64} command, which is identical to switching to C64
+To switch from MEGA65/C65 to C64-mode, use the familiar \screentext{GO 64} command, which is identical to switching to C64
 mode on a C128:
 \index{BASIC 65 Examples!GO64}
 \begin{tcolorbox}[colback=black,coltext=white]
@@ -241,7 +241,7 @@ by looking through
 \fi
 
 
-\subsection{Traps to look out for}
+\subsection{Traps to Look Out For}
 
 In all modes, the DOS for the internal 3.5'' disk drive (including when you use D81 disk images from
 an SD card) resets the KEY register to VIC-II mode whenever it is accessed. This means if you perform actions

--- a/settingup.tex
+++ b/settingup.tex
@@ -1,6 +1,6 @@
 \chapter{Setup}
 \phantomsection
-\section{Unpacking and connecting the MEGA65}
+\section{Unpacking and Connecting the MEGA65}
 Time to set up your MEGA65 home computer!
 The box contains the following:
 \begin{itemize}
@@ -65,7 +65,7 @@ joysticks, paddles or mouses.
 
 \newpage
 
-\section{MEGA65 screen and peripherals}
+\section{MEGA65 Screen and Peripherals}
 
 \includegraphics[width=\linewidth]{images/illustrations/mega65-top.pdf}
 


### PR DESCRIPTION
Old:
![image](https://user-images.githubusercontent.com/1773489/139066980-e438df85-dfae-49c4-b122-fb53d2d214ea.png)

New:
![image](https://user-images.githubusercontent.com/1773489/139067116-9c3f49b8-5910-43ed-8c0a-2e4b75747d5f.png)
