### PR TITLE
Update the BASIC 65 Command Reference intro.

### DIFF
--- a/appendix-basic65.tex
+++ b/appendix-basic65.tex
@@ -4,44 +4,45 @@
 
 \section{Commands, Functions and Operators}
 
-This appendix describes each of the commands, functions and other
-callable elements of BASIC 65, which is an enhanced version of BASIC 10.
-Some of these can take one or more arguments, which are pieces of input
-that you provide as part of the command or function call.
-Some also require that you use special keywords.
-Here is an example of how commands, functions and operators will be
-described in this appendix:
+This appendix describes each of the commands, functions and other callable
+elements of BASIC 65, which is an enhanced version of BASIC 10. Some of these
+can take one or more arguments, which are pieces of input that you provide as
+part of the command or function call. Some also require that you use special
+words.
 
-{\bf KEY <numeric expression>,<string expression> }
+Below is an example of how commands, functions and operators will be
+described in this appendix.
 
-In this case, KEY is what we call a \textbf{keyword}. That just means
-a special word that BASIC understands.
-Keywords are always written in CAPITALS, so that you can easily
-recognise them.
+{\bf KEY} number{\bf,} string
 
-The {\bf <} and {\bf >} signs mean that whatever is between them must
-be there for the command, function or operator to work.
-In this case, it tells us that we need to have a
-{\bf numeric expression} in one place, and a {\bf string expression}
-in another place.
-We'll explain what they are a bit more in a few moments.
+Here, {\bf KEY} is what we call a keyword. That just means a special word that
+BASIC understands. Keywords are always written in {\bf BOLD CAPITALS}, so that
+you can easily recognise them.
 
-You might also see square brackets around something. For example,
-{\bf [,numeric expression]}.
-This means that whatever appears between the square brackets is
-optional, that is, you can include it if you need to, but
-that the command, function or operator will work just fine without it.
-For example, the {\bf CIRCLE} command has
-an optional numeric argument to indicate if the circle should be filled
-when being drawn.
+The words not in bold must be replaced for the command, function or operator to
+work. In this example, we need to replace number with a numeric expression, and
+string with a string expression. We'll explain what expressions are a bit more
+in a few moments.
 
-The comma, and some other symbols and punctuation marks just represent themselves.
-In this case, it means that there must be a comma between the
-{\bf numeric expression} and the {\bf string expression}.
-This is what we call syntax: If you miss something out, or put the
-wrong thing in the wrong place, it is called a
-syntax error, and the computer will tell you if you have a syntax error
-by giving a \screentext{?SYNTAX ERROR} message.
+The comma, and some other symbols and punctuation marks, just represent
+themselves when they are in bold. In our example here, it means that there must
+be a comma between the number and the string.
+
+You might also see symbols and punctionation marks that are not in bold. When
+they are not in bold they have a special meaning. You might see square
+brackets around something. For example: [{\bf,} numeric expression]. This means
+that whatever appears between the square brackets is optional. That is, you can
+include it if you need to, but the command, function or operator will also work
+just fine without it. For example, the {\bf CIRCLE} command has an optional
+numeric argument to indicate if the circle should be filled when being drawn.
+
+See the table starting on page \pageref{meta-syntax table} for the meaning of
+the symbols not in bold.
+
+This arrangement of keywords, expressions and symbols is what we call syntax. If
+you miss something out, or put the wrong thing in the wrong place, it is called
+a syntax error. The computer will tell you you have a syntax error by giving
+a \screentext{?SYNTAX ERROR} message.
 
 There is nothing to worry about if you get an error from the computer.
 Instead, it is just the computer's way of telling you that something
@@ -414,6 +415,7 @@ low & OR XOR\\
 \newpage
 \section{BASIC Command Reference}
 
+\label{meta-syntax table}
 \begin{center}
 \setlength{\def\arraystretch{1.5}\tabcolsep}{6pt}
 \begin{longtable}{c|L{8cm}}


### PR DESCRIPTION
* Remove the reference to <> as argument markers.
* Align the KEY format here with that's under the KEY headword in the reference proper.
* Explain the distinction between bold and non-bold.
* Refer to the meta-syntax table.
* Move the explanation of bold symbols before the explanation of non-bold symbols. The bold symbols are an easier concept.