### PR TITLE
Fix description of ASRQ?

### DIFF
--- a/appendix-45gs02-registers.tex
+++ b/appendix-45gs02-registers.tex
@@ -476,7 +476,7 @@ For example, adding two 16-bit or 32-bit values can now be easily accomplished w
 This approach works with the LDA, STA, ADC, SBC, CMP, EOR, AND, BIT, ORA, ASL, ASR, LSR, ROL, ROR, INC and DEC instructions.
 If you are using ACME or another 45GS02 aware assembler, you can instead use the new \stw{LDQ}, \stw{STQ}, \stw{ADCQ},
 \stw{SBCQ}, \stw{CPQ}, \stw{EORQ}, \stw{ANDQ}, \stw{BITQ}, \stw{ORQ}, \stw{ASLQ}, \stw{ASRQ}, \stw{LSRQ}, \stw{ROLQ}, \stw{RORQ}, \stw{INQ} and \stw{DEQ}
-mnemonics.\index{LDQ}\index{STQ}\index{ADCQ}\index{SBCQ}\index{CPQ}\index{EORQ}\index{ANDQ}\index{BITQ}\index{ORQ}\index{ASLQ}\index{LSRQ}\index{ROLQ}\index{RORQ}\index{INQ}\index{DEQ} The previous example would thus become:
+mnemonics.\index{LDQ}\index{STQ}\index{ADCQ}\index{SBCQ}\index{CPQ}\index{EORQ}\index{ANDQ}\index{BITQ}\index{ORQ}\index{ASLQ}\index{ASRQ}\index{LSRQ}\index{ROLQ}\index{RORQ}\index{INQ}\index{DEQ} The previous example would thus become:
 
 \begin{tcolorbox}[colback=black,coltext=white]
 \verbatimfont{\codefont}


### PR DESCRIPTION
I noticed the description of ASRQ is a duplicate of ASLQ (directly above). I'm not aversed in the Latex format, but I think I found the cause for the missing matching data. 
There still needs to be a inst.ASRQ file!