### PR TITLE
NOTE: to Note: for consistency. And NOTE2: changed

### DIFF
--- a/appendix-petsciicodes.tex
+++ b/appendix-petsciicodes.tex
@@ -14,7 +14,7 @@ You can also do the reverse with the ASC statement.  For example:
 \screentext{PRINT ASC("A")} will output \screentext{65}, which matches with the
 code in the table.
 
-Note: Function key (F1-F14 + HELP) values in this table are not intended to be printed via CHR\$(),
+\underline{Note}: Function key (F1-F14 + HELP) values in this table are not intended to be printed via CHR\$(),
 but rather to allow function-key input to be assessed in BASIC programs via the GET / GETKEY commands.
 
 \index{Keyboard!PETSCII Codes and CHR\$}
@@ -219,10 +219,10 @@ but rather to allow function-key input to be assessed in BASIC programs via the 
 \end{multicols}
 \end{adjustwidth}
 
-Notes: 1. Codes from 192 to 223 are the equal to 96 to 127. Codes from 224 to 254 are equal to 160 to 190,
+\underline{Note 1}: Codes from 192 to 223 are the equal to 96 to 127. Codes from 224 to 254 are equal to 160 to 190,
 and code 255 is equal to 126.
 
-2. While using lowercase/uppercase mode (by pressing \megasymbolkey + \specialkey{SHIFT}), be aware that:
+\underline{Note 2}: While using lowercase/uppercase mode (by pressing \megasymbolkey + \specialkey{SHIFT}), be aware that:
 \begin{itemize}
   \item The uppercase letters in region 65-90 of the above table are replaced with lowercase letters.
   \item The graphical characters in region 97-122 of the above table are replaced with uppercase letters.

--- a/appendix-petsciicodes.tex
+++ b/appendix-petsciicodes.tex
@@ -14,7 +14,7 @@ You can also do the reverse with the ASC statement.  For example:
 \screentext{PRINT ASC("A")} will output \screentext{65}, which matches with the
 code in the table.
 
-NOTE: Function key (F1-F14 + HELP) values in this table are not intended to be printed via CHR\$(),
+Note: Function key (F1-F14 + HELP) values in this table are not intended to be printed via CHR\$(),
 but rather to allow function-key input to be assessed in BASIC programs via the GET / GETKEY commands.
 
 \index{Keyboard!PETSCII Codes and CHR\$}
@@ -219,10 +219,10 @@ but rather to allow function-key input to be assessed in BASIC programs via the 
 \end{multicols}
 \end{adjustwidth}
 
-NOTE: Codes from 192 to 223 are the equal to 96 to 127. Codes from 224 to 254 are equal to 160 to 190,
+Notes: 1. Codes from 192 to 223 are the equal to 96 to 127. Codes from 224 to 254 are equal to 160 to 190,
 and code 255 is equal to 126.
 
-NOTE2: While using lowercase/uppercase mode (by pressing \megasymbolkey + \specialkey{SHIFT}), be aware that:
+2. While using lowercase/uppercase mode (by pressing \megasymbolkey + \specialkey{SHIFT}), be aware that:
 \begin{itemize}
   \item The uppercase letters in region 65-90 of the above table are replaced with lowercase letters.
   \item The graphical characters in region 97-122 of the above table are replaced with uppercase letters.


### PR DESCRIPTION
As discussed in discord.
Changes NOTE: to Note: for consistency with the rest of the document.
Also Changed NOTE2: to Notes: 
I opted to not start a new line with 1. so it didn't shift the following pages out of whack. (I tested locally first)