### PR TITLE
Add a remark on how SYS maps memory when it's combined with BANK.

### DIFF
--- a/appendix-basic65.tex
+++ b/appendix-basic65.tex
@@ -9074,7 +9074,10 @@ THE VALUE OF PI IS 3.14159265
 \item [Remarks:] The register values after a {\bf SYS} call are stored
                  in system memory. {\bf RREG} can be used to retrieve these values.
 
-                 {\bf SYS} uses the current bank, which has been set with {\bf BANK}.
+                 {\bf SYS} maps addresses \$2000 - \$FFFF to the bank set with {\bf BANK},
+                 allowing you to call subroutines in any bank. Addresses \$0000 - \$1FFF
+                 remain unmapped and will access the RAM in bank 0. This means you can only
+                 call subroutines in addresses \$0000 - \$1FFF of {\bf BANK 0} and {\bf BANK 128}.
 
                  The {\bf SYS} instruction on the MEGA65 is completely different to the
                  well known {\bf SYS} command on the C64. It is not possible to jump


### PR DESCRIPTION
Particularly that it doesn't map the first block and addresses $0000-$1FFF is the RAM in bank 0 regardless of **BANK**.

I resisted the temptation to explain why **SYS** works this way. But I'm happy to give in to it if it's felt such an explanation would be warranted.