### PR TITLE
Add the individual asm instructions to the PDF table of contents.

### DIFF
--- a/appendix-instructionset.tex
+++ b/appendix-instructionset.tex
@@ -439,7 +439,9 @@ but are not guaranteed to produce exactly the same results as on other
 CPU's of the 65xx family. Many of these instructions are known to
 be unstable, even running on old hardware.
 
+\addtocontents{toc}{\protect\setcounter{tocdepth}{1}}
 \input{instructionset-6502}
+\addtocontents{toc}{\protect\setcounter{tocdepth}{5}}
 
 
 \section{4510 Instruction Set}
@@ -501,7 +503,9 @@ Similar issues apply to when the processor is in 6502 mode.
 \end{center}
 
 
+\addtocontents{toc}{\protect\setcounter{tocdepth}{1}}
 \input{instructionset-4510}
+\addtocontents{toc}{\protect\setcounter{tocdepth}{5}}
 
 \section{45GS02 Compound Instructions}
 
@@ -519,5 +523,7 @@ differently, as described in \bookvref{cha:cpu}.
 % Same goes for mode list.
 
 
+\addtocontents{toc}{\protect\setcounter{tocdepth}{1}}
 \input{instructionset-45GS02}
+\addtocontents{toc}{\protect\setcounter{tocdepth}{5}}
 

--- a/instruction_set.c
+++ b/instruction_set.c
@@ -402,10 +402,10 @@ int main(int argc, char** argv)
     is_unintended = strstr(short_description, "(unintended instruction)");
     if (is_unintended) {
       *is_unintended = 0;
-      printf("\n\n\\subsection*{\\textcolor{red}{%s [unintended]}}\n", instruction);
+      printf("\n\n\\subsection{\\textcolor{red}{%s [unintended]}}\n", instruction);
     }
     else
-      printf("\n\n\\subsection*{%s}\n", instruction);
+      printf("\n\n\\subsection{%s}\n", instruction);
     printf("\\index{%s}%s\n\n\n", instruction, long_description);
 
     int delmodify65ce02_note_seen = 0;


### PR DESCRIPTION
This is just the table of contents that appears in the PDF viewer, not the table of contents LaTeX produces on the actual pages.

This is makes it easier to locate and jump between the instructions, without having to go via the index pages.