### PR TITLE
Fixed command byte for both FILL and CHAIN

### DIFF
--- a/appendix-dmagic.tex
+++ b/appendix-dmagic.tex
@@ -226,7 +226,7 @@ also clear the colour RAM for the screen, you could use something like:
   RTS
 
 dmalist:
-  .byte $04   ; Command low byte: FILL + CHAIN
+  .byte $07   ; Command low byte: FILL + CHAIN
   .word 2000  ; Count: 80x25 = 2000 bytes
   .word $0020 ; Fill with value $20
   .byte $00   ; Source bank (ignored with FILL operation)


### PR DESCRIPTION
Was 4 before which is just CHAIN and needs to be 7 to be FILL | CHAIN