### PR TITLE
NCM/FCM clarification and relocate char data fix

### DIFF
--- a/appendix-viciv-registers.tex
+++ b/appendix-viciv-registers.tex
@@ -296,9 +296,9 @@ REM ENABLE C65+MEGA65 I/O
 IF PEEK($D018)<32 THEN POKE $D02F,ASC("G"):POKE $D02F,ASC("S")
 REM HEX $41200 IS EASILY DIVIDED IN ITS 3 BYTES $00, $12, $4
 REM BUT YOU CAN ALSO USE MATH TO EXTRACT THE PARTS
-POKE $D060,(266752-INT(266752/65536)*$10000) AND 255
-POKE $D061,INT((266752-INT(266752/65536)*65536)/256)
-POKE $D062,INT(266752/65536)
+POKE $D068,(266752-INT(266752/65536)*$10000) AND 255
+POKE $D069,INT((266752-INT(266752/65536)*65536)/256)
+POKE $D06A,INT(266752/65536)
 \end{verbatim}
 \end{tcolorbox}
 
@@ -550,12 +550,14 @@ normally be used with Super-Extended Attribute Mode (SEAM), so that more than 25
 the selection of 8,192 unique characters, this allows FCM character data to be placed anywhere in the first 512KB of chip RAM (but
 note that most models of the MEGA65 have only 384KB of chip RAM).
 
+Please note that the pixel value \$ff will not select the corresponding colour code directly. Instead, it will select the colour code defined by the colour RAM.
+
 \subsection{Nibble-colour (16 colours per character) Text Mode (NCM)}
 
 The Nibble-Colour Mode (NCM) for text is similar to Full-Colour Text Mode, except that each byte of data describes two
 pixels using 4 bits each. This makes the NCM unique, because the characters will be 16 pixels wide, instead of the usual 8 pixels wide. This can be used to create colourful displays, without using as much memory as FCM, because fewer characters are required to cover the screen.  Unlike the VIC-II's MCM, this mode does not result in a loss of horizontal resolution.
 
-In NCM the lower four bits of the pixel colour comes from the upper or lower four bits of the pixel data.  The upper four bits of the colour code come from the colour RAM data for the displayed character.  This makes it possible to use all palette entries in NCM, although the limitation of 16 colours per character remains.
+In NCM the lower four bits of the pixel colour comes from the upper or lower four bits of the pixel data.  The upper four bits of the colour code come from the colour RAM data for the displayed character.  This makes it possible to use all palette entries in NCM, although the limitation of 16 colours per character remains. Similar to the behaviour of FCM, the pixel data value \$f will select the pixel colour set in the colour RAM.
 
 A further advantage of NCM is that it uses fewer bus cycles per pixel than FCM, because fewer character data fetches need to occur per raster line.  Together with the reduced memory requirements, this makes NCM particularly useful for creating colourful multiple layers of graphics.  This allows the VIC-IV to display arcade style displays with more colours than many 16-bit computers.
 

--- a/appendix-viciv-registers.tex
+++ b/appendix-viciv-registers.tex
@@ -286,8 +286,7 @@ POKE $D060,$45:POKE $D061,$23:POKE $D062,$1
 The location of the character generator data can also be set with byte-level precision via the CHARPTR registers at \$D068 -- \$D06A (53352 -- 53354 decimal). As usual, the first of these registers holds the lowest-order byte, and the last the highest-order byte. The three bytes allow for placement of character data anywhere in the first 16MB of RAM. For systems with less than 16MB of RAM accessible by the VIC-IV, the upper address bits should be zero.
 
 For example, to indicate that character generator data should be sourced beginning at \$41200 (266752 decimal), the following
-could be used.  Note that the AND binary operator only works with arguments between 0 and 65,535. Therefore we first
-subtract 4$\times$65,536 = 262,144 from the address (the 4 is determined by calculating INT(266752/65536) ), before we use the AND operator to compute the lower part of the address:
+could be used.  Note that the command POKEW can be used to write two bytes as a word into a memory or I/O location. Therefore, we use POKEW to write \$00 into \$D068 and \$12 into \$D069, and an additional POKE to write the high byte \$A into \$D06A by dividing the address by 65536:
 
 \begin{tcolorbox}[colback=black,coltext=white]
 \verbatimfont{\codefont}
@@ -295,10 +294,11 @@ subtract 4$\times$65,536 = 262,144 from the address (the 4 is determined by calc
 REM ENABLE C65+MEGA65 I/O
 IF PEEK($D018)<32 THEN POKE $D02F,ASC("G"):POKE $D02F,ASC("S")
 REM HEX $41200 IS EASILY DIVIDED IN ITS 3 BYTES $00, $12, $4
-REM BUT YOU CAN ALSO USE MATH TO EXTRACT THE PARTS
-POKE $D068,(266752-INT(266752/65536)*$10000) AND 255
-POKE $D069,INT((266752-INT(266752/65536)*65536)/256)
-POKE $D06A,INT(266752/65536)
+REM POKEW SETS THE LOWER TWO BYTES IN ONE COMMAND AND
+REM THE FOLLOWING POKE SETS THE UPPER BYTE
+A=$41200
+POKEW $D068,A
+POKE $D06A,A/65536
 \end{verbatim}
 \end{tcolorbox}
 


### PR DESCRIPTION
* FCM and NCM treat pixel data $ff (FCM) and $f (NCM) in a special way
* Fix wrong addresses in  "Relocating Character Generator Data" example