### PR TITLE
Fixed Absolute Indirect X-Indexed Mode example

### DIFF
--- a/appendix-instructionset.tex
+++ b/appendix-instructionset.tex
@@ -238,7 +238,7 @@ In this mode, the 16-bit argument is the address that points to, i.e., contains 
 address of actual byte to read. It is identical to Absolute Indirect Mode, except that
  the value of the X Register is added to the pointer address.
 For example, if the X Register contains the value \$04, memory location \$1238 contains \$78
-and memory location \$1239 contains \$56, then \screentext{JMP (\$1234)} would jump
+and memory location \$1239 contains \$56, then \screentext{JMP (\$1234,X)} would jump
 to address \$5678.
 The encoding for this addressing mode is identical to Absolute Mode.
 


### PR DESCRIPTION
the example was: JMP ($1234) but should have been JMP ($1234,X)