### PR TITLE
Fixed type on 32-bit address example

### DIFF
--- a/appendix-45gs02-registers.tex
+++ b/appendix-45gs02-registers.tex
@@ -433,7 +433,7 @@ Regardless which tool you are using, this example would read the four bytes of Z
 Z register to this to form the actual address that will be read from.  The byte order in the address is the same as
 the 6502, i.e., the right-most (least significant) byte of the address will be read from the first address (\$45 in this case),
 and so on, until the left-most (most significant) byte will be read from \$48.  For example, to read from memory location
-\$12345678, the contents of memory beginning at \$45 should be 78 56 43 12.
+\$12345678, the contents of memory beginning at \$45 should be 78 56 34 12.
 
 This method is much more efficient and also simpler than either using the MAP instruction or the DMA controller for single memory accesses,
 and is what we generally recommend.  The DMA controller can be used for moving/filler larger regions of memory.


### PR DESCRIPTION
Fixed typo for 32-bit address example where the text was '43' instead of '34'