### PR TITLE
Spelling fix on appendix-memorymap.tex

### DIFF
--- a/appendix-memorymap.tex
+++ b/appendix-memorymap.tex
@@ -111,7 +111,7 @@ freeze cartridge currently freezes only the first 384KB of RAM.
 The MEGA65's VIC-IV video controller supports much larger screens than the VIC-II or VIC-III. For this reason, it
 has access to a separate colour RAM, similar to on the C64.  For compatibility with the C65, the first two kilo-bytes
 of this are accessible at \$1F800 -- \$1FFFF.  The full 32KB or 64KB of colour RAM is located at \$FF80000.
-This is most easily access through the use of advanced DMA operations, or the 32-bit base-page indirect addressing
+This is most easily accessed through the use of advanced DMA operations, or the 32-bit base-page indirect addressing
 mode of the processor.
 
 At the time of writing, the \stw{BANK} and \stw{DMA} commands cannot be used to access the rest of the colour RAM, because the


### PR DESCRIPTION
This is most easily access through -> This is most easily accessed through