### PR TITLE
Add mention of new ESC Home feature (ROM 920362); gitignore & README cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -267,6 +267,13 @@ appendix-basic65-indexed.tex
 examples/ledcycle.tex
 examples/ledcycle.txt
 gitinfo.tex
+keymap
+keymap_table_1.tex
+keymap_table_2.tex
+keymap_table_3.tex
+keymap_table_4.tex
+keymap_table_5.tex
+unicode_mapping.tex
 
 # compiled binaries
 document-memory

--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,7 @@ GENERATED_TEX_FILES= 	document-memory \
 
 COMPILED_BINARIES= 	document-memory \
 			generate_condensed \
+			keymap \
 			index_basic_programmes \
 			instruction_set \
 			libc-doc \

--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
 # MEGA65 User Guide
+
 This is community effort to create a User Guide for the MEGA65 in the spirit of the original User Guide for the Commodore 64.
 
 # Just show me the PDFs!
 
 If you just want the typeset manuals, the latest pdf's from our build pipeline are available here:
-* https://files.mega65.org/manuals-upload/
+
+-   https://files.mega65.org/manuals-upload/
 
 (Location will be updated to files.mega65.org at a later stage when our automation permits it)
 
@@ -15,13 +17,15 @@ https://github.com/MEGA65/mega65-user-guide/releases
 # Installation
 
 ## Requirements
-* MingW32 (tested on MinGW-6.3.0, and MinGW-8.1.0) for Windows or GCC Compiler for Linux / Mac OS X.
-* This project repo.
-* The mega65-core repo: https://github.com/MEGA65/mega65-core is required for the memory tables included in the User Guide.
-* The Simple C library for the MEGA65: https://github.com/MEGA65/mega65-libc is required to create api-conio.tex
-* A typesetting environment that supports XeLaTeX, for example: http://www.tug.org/texworks/ for Windows.
+
+-   MingW32 (tested on MinGW-6.3.0, and MinGW-8.1.0) for Windows or GCC Compiler for Linux / Mac OS X.
+-   This project repo.
+-   The mega65-core repo: https://github.com/MEGA65/mega65-core is required for the memory tables included in the User Guide. Clone `mega65-core` to the parent directory of this repo.
+-   The Simple C library for the MEGA65: https://github.com/MEGA65/mega65-libc is required to create api-conio.tex. Clone `mega65-libc` to the parent directory of this repo.
+-   A typesetting environment that supports XeLaTeX, for example: http://www.tug.org/texworks/ for Windows.
 
 # Usage
+
 The User Guide project is defined using a Makefile to build. Therefore if you are using an environment like TeXworks, do not use the built in Build button. That is for single file building only. For MingW32 users, just use:
 
 `mingw32-make` or `mingw32-make mega65-userguide.pdf` in the main folder of the project to build the mega65-userguide.pdf file.
@@ -40,18 +44,17 @@ The sandbox is faster to build and test changes more quickly. You can then trans
 
 The complete list of guides that can be individually built are:
 
-| Book       | Build     |
-| :------------- | :---------- |
-| User Guide | make mega65-userguide.pdf |
-| Chipset Reference   | make mega65-chipset-reference.pdf |
-| Complete BASIC 65 Commands | make mega65-basic65-reference.pdf |
-| For experimentation (don't commit) | make sandbox.pdf |
-| Reference Guide | make referenceguide.pdf |
-| Developer's Guide | make mega65-developer-guide.pdf |
-| Guide to MEGA65 and FPGA Hardware | make hardwareguide.pdf |
-| All books combined | make mega65-book.pdf |
-| As above but in CYMK for printing (Ghostscript required) | make mega65-book-cmyk.pdf: |
-
+| Book                                                     | Build                             |
+| :------------------------------------------------------- | :-------------------------------- |
+| User Guide                                               | make mega65-userguide.pdf         |
+| Chipset Reference                                        | make mega65-chipset-reference.pdf |
+| Complete BASIC 65 Commands                               | make mega65-basic65-reference.pdf |
+| For experimentation (don't commit)                       | make sandbox.pdf                  |
+| Reference Guide                                          | make referenceguide.pdf           |
+| Developer's Guide                                        | make mega65-developer-guide.pdf   |
+| Guide to MEGA65 and FPGA Hardware                        | make hardwareguide.pdf            |
+| All books combined                                       | make mega65-book.pdf              |
+| As above but in CYMK for printing (Ghostscript required) | make mega65-book-cmyk.pdf:        |
 
 # MAC OSX
 
@@ -82,6 +85,7 @@ Calling "make" with the target twice is intentional and needed for getting all r
 Of course, you can create a shell script for these three lines.
 
 # Linux
+
 For Linux users, the instructions are the similar, but use your favourite package manager to install a LaTeX package of your choice.
 
 # Editors
@@ -90,6 +94,6 @@ For Linux users, the instructions are the similar, but use your favourite packag
 
 Combined with the `LaTeX Workshop` extension, this is a great IDE for working with the project. However be careful of the using the built-in terminal for compiling the guides. It's a powershell-based terminal and won't work with the Makefile. Nor will Command Prompt. Use a more Unix styled terminal like Git Bash.
 
-
 ## Style Guide
-If you wish to contribute to the MEGA65 literature, please try to read and follow the [style-guide](style-guide.md). 
+
+If you wish to contribute to the MEGA65 literature, please try to read and follow the [style-guide](style-guide.md).

--- a/appendix-petsciicodes.tex
+++ b/appendix-petsciicodes.tex
@@ -462,6 +462,9 @@ to the saved position. Note that the \megakeywhite{$\uparrow$} used here is next
 Restores the cursor position to the position stored via a prior a press of the \specialkey{ESC}
     \megakeywhite{$\uparrow$}
 (next to \widekey{RESTORE}) key sequence. Note that the \megakeywhite{$\leftarrow$} used here is next to \megakey{1}.\\
+\hline
+\specialkey{ESC} \specialkey{HOME} &
+Restores the cursor position to the position stored via a prior a press of \specialkey{HOME}.\\
 
   \hhline{==}
   \multicolumn{2}{l}{\textbf{Windowing}} \\


### PR DESCRIPTION
This adds the ESC Home feature introduced in ROM 920362 to the Escape Sequences section of the User Guide appendix.

This also adds keymap as a recognized generated asset, so a clean build now succeeds.

I added notes to the set-up instructions in the README about where the dependent repos go (in the parent directory). My editor decided to normalize some Markdown formatting; sorry about that. :)