### PR TITLE
Fix 'exactly' repeated and avoid line break after '~'

### DIFF
--- a/appendix-viciv-registers.tex
+++ b/appendix-viciv-registers.tex
@@ -238,8 +238,7 @@ Standard Definition TV modes used by the C64. The frame parameters of the VIC-IV
 	\small NTSC & 65 & 526 & 263  \\
 \end{longtable}
 
-The result is that the frames on the VIC-IV consist of exactly the same
- number of $\sim$ 1MHz CPU cycles as on the VIC-II exactly.
+The result is that the frames on the VIC-IV consist of exactly the same number of $\sim$1MHz CPU cycles as on the VIC-II.
 
 \subsubsection{Bad Lines}
 


### PR DESCRIPTION
Fix the word 'exactly' repeated and avoid line break after '~' in appendix-viciv-registers.tex