### PR TITLE
Add LLVM mos compiler

### DIFF
--- a/ccompilers.tex
+++ b/ccompilers.tex
@@ -29,6 +29,9 @@ even download and compile CC65, if you don't already have it installed
 on your system.  This repository should work on Linux and Mac, and
 on Windows under the Windows Subsystem for Linux (WSL).
 
+The LLVM compiler for MOS (\url{https://llvm-mos.org/wiki/Welcome}) also
+has a rudimentary MEGA65 target that has been tested with C99, C++11, and Rust.
+
 \section{MEGA65 libc}
 
 A C library is being developed for the MEGA65, and which already

--- a/ccompilers.tex
+++ b/ccompilers.tex
@@ -29,8 +29,11 @@ even download and compile CC65, if you don't already have it installed
 on your system.  This repository should work on Linux and Mac, and
 on Windows under the Windows Subsystem for Linux (WSL).
 
-The LLVM compiler for MOS (\url{https://llvm-mos.org/wiki/Welcome}) also
+The LLVM compiler for MOS (\url{https://llvm-mos.org}) also
 has a rudimentary MEGA65 target that has been tested with C99, C++11, and Rust.
+The LLVM MOS compiler has experimental support for 65CE02 instructions
+(\texttt{-mcpu=mosw65ce02}) and development is ongoing.
+
 
 \section{MEGA65 libc}
 


### PR DESCRIPTION
This mentions lthe lvm-mos compiler to the "C and C-like compilers" section for C99, C++, and Rust development.