### PR TITLE
Fix screenoutput block in VIC-IV registers

### DIFF
--- a/appendix-viciv-registers.tex
+++ b/appendix-viciv-registers.tex
@@ -292,9 +292,7 @@ REM THE FOLLOWING POKE SETS THE UPPER BYTE
 A=$41200
 POKEW $D068,A
 POKE $D06A,A/65536
-\end{verbatim}
-\end{tcolorbox}
-
+\end{screenoutput}
 
 \subsection{Relocating Colour / Attribute RAM}
 


### PR DESCRIPTION
This fix makes the following chapter (Relocating Color/Attribute RAM) render correctly again.