### PR TITLE
Disable addressing modes documented as having no instructions

### DIFF
--- a/appendix-instructionset.tex
+++ b/appendix-instructionset.tex
@@ -151,7 +151,7 @@ The argument is encoded as a single byte that immediately follows the instructio
 example,
 
 \begin{screenoutput}
-LDA #12
+LDA $12
 \end{screenoutput}
 
 would read the value stored in location \$12 in the Base-Page,

--- a/appendix-instructionset.tex
+++ b/appendix-instructionset.tex
@@ -244,6 +244,9 @@ and put it into the X register.  The instruction byte stream for this would be \
 
 See the note on page \pageref{Base-Page (Zero-Page) Mode} for more information about Base-Page and Zero-Page.
 
+
+% Disabled: "no instructions currently offer this addressing mode"
+\iffalse
 \subsection{Base-Page Quad Y-Indexed Mode}
 
 This mode is identical to Base-Page Quad Mode, except that the address is formed by taking the
@@ -255,7 +258,10 @@ Mode.
 Note that no instructions currently offer this addressing mode.
 
 See the note on page \pageref{Base-Page (Zero-Page) Mode} for more information about Base-Page and Zero-Page.
+\fi
 
+% Disabled: "no instructions currently offer this addressing mode"
+\iffalse
 \subsection{Base-Page Z-Indexed Mode}
 
 This mode is identical to Base-Page Mode, except that the address is formed by taking the
@@ -267,7 +273,10 @@ Mode.
 Note that no instructions currently offer this addressing mode.
 
 See the note on page \pageref{Base-Page (Zero-Page) Mode} for more information about Base-Page and Zero-Page.
+\fi
 
+% Disabled: "no instructions currently offer this addressing mode"
+\iffalse
 \subsection{Base-Page Quad Z-Indexed Mode}
 
 This mode is identical to Base-Page Quad Mode, except that the address is formed by taking the
@@ -279,6 +288,7 @@ Mode.
 Note that no instructions currently offer this addressing mode.
 
 See the note on page \pageref{Base-Page (Zero-Page) Mode} for more information about Base-Page and Zero-Page.
+\fi
 
 \subsection{Absolute Mode}
 
@@ -342,7 +352,7 @@ For example, the instruction
 ROLQ $1234,X
 \end{screenoutput}
 
-would rotate left the 32-bit value 
+would rotate left the 32-bit value
 at memory locations (\$1234+X) -- (\$1237+X), and write the result back to these same memory locations.  This would
 be encoded as \$42 \$42 \$3E \$34 \$12.
 
@@ -365,6 +375,8 @@ would read the
 memory location (\$1234 + Y), and place the value read from there into the A Register.  This would
 be encoded as \$B9 \$34 \$12.
 
+% Disabled: "no instructions currently offer this addressing mode"
+\iffalse
 \subsection{Absolute Quad Y-Indexed Mode}
 
 This mode is identical to Absolute Quad Mode, except that the address is formed by taking the
@@ -376,6 +388,7 @@ The encoding for this addressing mode is identical to Absolute Quad Mode.
 Note that no instructions currently offer this addressing mode.
 
 See the note on page \pageref{Base-Page (Zero-Page) Quad Mode} for more information on Quad Mode instructions.
+\fi
 
 \subsection{Absolute Indirect Mode}
 
@@ -427,6 +440,8 @@ and store the result in the A register. This instruction would be encoded as \$A
 
 See the note on page \pageref{Base-Page (Zero-Page) Mode} for more information about Base-Page and Zero-Page.
 
+% Disabled: "no instructions currently offer this addressing mode"
+\iffalse
 \subsection{Base-Page Quad Indirect X-Indexed Mode}
 
 This addressing mode is identical to Base-Page Indirect X-Indexed Mode, except that the address
@@ -437,6 +452,7 @@ Note that no instructions currently offer this addressing mode.
 
 See the note on page \pageref{Base-Page (Zero-Page) Mode} for more information about Base-Page and Zero-Page.
 See the note on page \pageref{Base-Page (Zero-Page) Quad Mode} for more information on Quad Mode instructions.
+\fi
 
 \subsection{Base-Page Indirect Y-Indexed Mode}
 
@@ -444,7 +460,7 @@ This addressing mode differs from the X-Indexed Indirect modes, in that the Y Re
 added to the address that is read from the pointer, instead of being added to the pointer.
 This is a very useful mode, that is frequently used because it effectively provides access to
 ``the Y-th byte of the memory at the address pointed to by the operand.'' That is, it de-references
-a pointer.  
+a pointer.
 The encoding for this addressing mode is identical to Base-Page Mode.
 
 For example, if the Y Register contains the value \$04, and the memory locations \$12 and \$13 in the current
@@ -460,6 +476,8 @@ and store the result in the A register. This instruction would be encoded as \$B
 
 See the note on page \pageref{Base-Page (Zero-Page) Mode} for more information about Base-Page and Zero-Page.
 
+% Disabled: "no instructions currently offer this addressing mode"
+\iffalse
 \subsection{Base-Page Quad Indirect Y-Indexed Mode}
 
 This addressing mode is identical to the Base-Page Indirect Y-Indexed Mode, except that
@@ -470,6 +488,7 @@ Note that no instructions currently offer this addressing mode.
 
 See the note on page \pageref{Base-Page (Zero-Page) Mode} for more information about Base-Page and Zero-Page.
 See the note on page \pageref{Base-Page (Zero-Page) Quad Mode} for more information on Quad Mode instructions.
+\fi
 
 \subsection{Base-Page Indirect Z-Indexed Mode}
 
@@ -512,7 +531,7 @@ LDQ ($12),Z
 would read the contents of memory location \$ABD1 (i.e., \$ABCD + Y) -- \$ABD4
 and store the result in the Q Pseudo Register. This instruction would be encoded as \$42 \$42 \$B2 \$12.
 
-Currently the only instruction that offers this mode is LDQ. 
+Currently the only instruction that offers this mode is LDQ.
 
 See the note on page \pageref{Base-Page (Zero-Page) Mode} for more information about Base-Page and Zero-Page.
 See the note on page \pageref{Base-Page (Zero-Page) Quad Mode} for more information on Quad Mode instructions.
@@ -726,7 +745,7 @@ marked blue, a base-page indirect Z indexed opcode that can use 32-bit pointers 
     & \$x0 & \$x1 & \$x2 \\\hline
     \multicolumn{1}{|c|}{\$0x} & \OPC{OPC}{mode}{size}{cyc} & \OPquad\OPCQ{QOP}{mode}{size}{cyc} & \OPfarq\OPCQ{FARQ}{IbpZ}{size}{cyc} \\\hline
   \end{tabular}
-\end{center}  
+\end{center}
 
 The letters attached to the cycle count have the following meaning:
 


### PR DESCRIPTION
Six addressing modes are documented as currently having no instructions that support them. This PR disables the mention of these modes, but retains the text in the source file for later.

Disabled:
- Base-Page Quad Y-Indexed Mode
- Base-Page Z-Indexed Mode
- Base-Page Quad Z-Indexed Mode
- Absolute Quad Y-Indexed Mode
- Base-Page Quad Indirect X-Indexed Mode
- Base-Page Quad Indirect Y-Indexed Mode

Related modes that are not documented as having no instructions are still enabled:
- Base-Page X-Indexed Mode
- Base-Page Y-Indexed Mode  (removes Z)
- Base-Page Quad X-Indexed Mode  (removes Y, Z)
- Absolute Quad X-Indexed Mode  (removes Y)
- Base-Page Quad Indirect Z-Indexed Mode  (removes X, Y)