### PR TITLE
Removed deprecated section "CPU Speed Fine-Tuning"

### DIFF
--- a/appendix-45gs02-registers.tex
+++ b/appendix-45gs02-registers.tex
@@ -157,20 +157,6 @@ LDA, LDX, LDY and LDZ instructions. Those instructions typically require one add
 However as the processor is running at 40MHz, these instructions still execute much more quickly
 than on even a C65 or C64 with an accelerator.
 
-\subsubsection{CPU Speed Fine-Tuning}
-It is also possible to more smoothly
-vary the CPU speed using the {\bf SPEEDBIAS} register located at \$D7FA (55290), when MEGA65 I/O mode
-is enabled.  The default value is \$80 (128), which means no bias on the CPU speed.  Higher values
-increase the CPU speed, with \$FF meaning $2\times$ the expected speed. Lower values slow
-the processor down, with \$00 bring the CPU to a complete stand-still.  Thus the speed can be
-varied between $0\times$ and $2\times$ the intended value.
-
-This register is provided to allow tweaking the processor speed in games.
-
-Note that this register has no effect when
-the processor is running at full-speed, because it only affects the way in which VIC-IV
-video cycle indication pulses are processed by the CPU.
-
 \subsubsection{Direct Memory Access (DMA)}
 Direct Memory Access (DMA) is a method for quickly filling, copying or swapping memory regions.
 The MEGA65 implements an improved version of the F018 ``DMAgic'' DMA controller of the C65 prototypes.


### PR DESCRIPTION
The section mentioned describes usage of register $d7fa to fine-tune the CPU speed (SPEEDBIAS). This register is no longer available, and is used for FRAMECOUNT instead. Thus, we should remove the outdated section.