### PR TITLE
Document 80x50 mode, new in ROM 920382

### DIFF
--- a/appendix-basic65.tex
+++ b/appendix-basic65.tex
@@ -280,7 +280,9 @@ Many programmers like to skip the standard routine {\bf PRINT} for screen output
 and want to access the screen memory and the colour RAM directly
 using the commands {\bf PEEK} and {\bf POKE}.
 {\bf BASIC 65} provides a method for direct access, that is easier to use
-and faster than {\bf POKE}:
+and faster than {\bf POKE}. This method also accounts for the VIC-IV's ability
+to relocate screen memory, so you do not need to read a register to determine
+the {\bf POKE} address.
 
 Two byte arrays are predefined, that are mapped to screen text memory
 and screen colour memory.
@@ -289,26 +291,26 @@ and screen colour memory.
 
 \screentextwide{ C@\&(COLUMNS,ROWS)} is mapped to the colour screen memory.
 
-In 80 column mode the arrays are dimensioned as:
+In 80 $\times$ 25 text mode the arrays are dimensioned as:
 
 \screentextwide{ T@\&(79,24)} Column = 0 - 79, Row = 0 - 24.
 
 \screentextwide{ C@\&(79,24)} Column = 0 - 79, Row = 0 - 24.
 
-In 40 column mode the arrays are dimensioned as:
+In 80 $\times$ 50 text mode the arrays are dimensioned as:
+
+\screentextwide{ T@\&(79,24)} Column = 0 - 79, Row = 0 - 49.
+
+\screentextwide{ C@\&(79,24)} Column = 0 - 79, Row = 0 - 49.
+
+In 40 $\times$ 25 text mode the arrays are dimensioned as:
 
 \screentextwide{ T@\&(39,24)} Column = 0 - 39, Row = 0 - 24.
 
 \screentextwide{ C@\&(39,24)} Column = 0 - 39, Row = 0 - 24.
 
 If you want to display the character {\bf A} (display code = 1)
-in row 2 and column 5 and make it yellow, you can either use the POKE method:
-
-\screentextwide{POKE 2213,1} address = 2048 + 2 * 80 +5 = 2213
-
-\screentextwide{POKE \$FF808A5,7} 7 = YELLOW.
-
-or use the mapped byte arrays:
+in row 2 and column 5 and make it yellow, use the mapped byte arrays:
 
 \screentextwide{T@\&(5,2) = 1} character A
 

--- a/appendix-petsciicodes.tex
+++ b/appendix-petsciicodes.tex
@@ -393,15 +393,23 @@ then press one of the following keys to perform the sequence:
   \hhline{==}
 
 \specialkey{ESC} \megakey{X} &
-Clears the screen and toggles between 40 and 80-column modes.\\
+Clears the screen and toggles between 40 $\times$ 25 and 80 $\times$ 25 text modes.\\
 \hline
 
 \specialkey{ESC} \megakey{4} &
-Clears the screen and switches to 40 column mode.\\
+Clears the screen and switches to 40 $\times$ 25 text mode.\\
 \hline
 
 \specialkey{ESC} \megakey{8} &
-Clears the screen and switches to 80 column mode.\\
+Clears the screen and switches to 80 $\times$ 25 text mode.\\
+\hline
+
+\specialkey{ESC} \megakey{5} &
+Switches to 80 $\times$ 50 text mode.\\
+\hline
+\multicolumn{2}{L{7cm}}{
+  Note that some programs expect to be started in 80 $\times$ 25 mode,
+  and may not behave correctly when started in 80 $\times$ 50 mode.} \\
 \hline
 
 \specialkey{ESC} \megakey{@} &


### PR DESCRIPTION
ROM 920382 adds an 80x50 (ESC+5) text mode to the BASIC 65 environment, complementing the 80x25 (ESC+8) and 40x25 (ESC+4) text modes. The `T@&` and `C@&` have corresponding larger ranges in this mode. https://github.com/MEGA65/mega65-rom/pull/13

I also removed one mention of POKE'ing screen memory, because the location is not the same in all text modes. BASIC programs should usually use `T@&` and `C@&` to access screen and color memory, or they can read VIC-IV registers to locate screen memory.

![CleanShot 2023-02-22 at 01 47 04](https://user-images.githubusercontent.com/408973/220583541-b891daf3-deeb-42c6-a2d2-84c961767ed2.png)
![CleanShot 2023-02-22 at 01 47 28](https://user-images.githubusercontent.com/408973/220583635-87bc30fb-b89a-4376-8425-cee79839e4b0.png)
