### PR TITLE
Update libc.tex

### DIFF
--- a/libc.tex
+++ b/libc.tex
@@ -6,9 +6,6 @@ includes a number of useful features. This library is available from
 functions and definitions it provides are documented in a separate
 chapter.
 
-The MEGA65 libc is currently available only for CC65, although we would
-welcome someone maintaining a KickC port of it.
-
 \section{Structure and Usage}
 
 The MEGA65 libc is purposely provided in source-form only, and with groups


### PR DESCRIPTION
Libc is available for cc65 and llvm, but no need to mention this here.