### PR TITLE
Minor English fixes in memory map appendix

### DIFF
--- a/appendix-memorymap.tex
+++ b/appendix-memorymap.tex
@@ -359,7 +359,7 @@ The 45GS10 processor, like the 6502, can only ``see'' 64KB of memory
 at a time. Access to additional memory is via a selection of
 bank-switching mechanisms.  For backward-compatibility with the C64
 and C65, the memory banking mechanisms for both of these computers
-existing the MEGA65:
+are supported on the MEGA65:
 \begin{enumerate}
 \item C65-style MAP instruction banking
 \item C65-style \$D030 banking
@@ -443,7 +443,7 @@ un-hidden.
 
 The current write-protection
 state can be tested by attempting to write to this area of memory.
-Also, you can examine and toggle the current state from in the MEGA65
+Also, you can examine and toggle the current state in the MEGA65
 Freeze Menu.
 
 NOTE: If you are starting your program from C65-mode, you must first make


### PR DESCRIPTION
A couple little things I noticed while reading this section again.

Wasn't sure if the first should be "in the MEGA65" or "on the MEGA65".  They both sounds ok to me, so probably just a style thing.  Searching shows many instances of both ways.

The second one could also be "from within" if that's preferred.