### PR TITLE
Remove escape from screenoutput block

### DIFF
--- a/appendix-instructionset.tex
+++ b/appendix-instructionset.tex
@@ -398,7 +398,7 @@ address of actual byte to read.  For example, if memory location \$1234 contains
 and memory location \$1235 contains \$56, then
 
 \begin{screencode}
-JMP (\$1234)
+JMP ($1234)
 \end{screencode}
 
 would jump


### PR DESCRIPTION
The escaped $ was causing the output to have an extra British pound symbol in the example.