### PR TITLE
Fix a couple matrix monitor typos

### DIFF
--- a/appendix-monitor.tex
+++ b/appendix-monitor.tex
@@ -870,7 +870,7 @@ see the screen output of your running program at the same time.
 \item [Format:] {\bf <m|M> [address]}
 \item [Usage:] Prints a memory dump for the given 28-bit address.
   If you wish to inspect the contents of memory as currently seen
-  by the processor's current banking configuration, use the \@
+  by the processor's current banking configuration, use the {\bf @}
   command instead.
 
   The dump displays memory contents, organised in rows
@@ -881,7 +881,7 @@ see the screen output of your running program at the same time.
   followed by the character representation.
 
   To view memory from the CPU's current memory context, taking into account
-  current memory banking, prefix the address with 777, e.g., {\tt d777080D}
+  current memory banking, prefix the address with 777, e.g., {\tt m777080D}
   would view memory at \$080D, as currently visible to the MEGA65's processor.
 
 


### PR DESCRIPTION
The escaped `@` symbol (`\@`) means something special in TeX so it wasn't being rendered as an `@`.  Plus there was a small copy and paste error in the in-line example