### PR TITLE
Align the monitor documentation for the `J` cmd with the impl.

### DIFF
--- a/appendix-monitor.tex
+++ b/appendix-monitor.tex
@@ -353,8 +353,8 @@ FONT C : REM $02D000 : original C64 font
 \index{JUMP}
 \index{MONITOR Commands!JUMP}
 \begin{description}[leftmargin=2cm,style=nextline]
-\item [Format:] {\bf J addr}
-\item [Usage:] Jumps to a subroutine at an address.
+\item [Format:] {\bf J [addr]}
+\item [Usage:] Jumps to a subroutine at an address. If {\bf addr} is omitted, the current program counter is used as the address.
 
 \item [Remarks:] This is equivalent to a {\bf JSR} instruction. When the subroutine returns with {\tt RTS}, the monitor resumes.
 


### PR DESCRIPTION
The actual code for the `J` command will default to the current PC value if no argument is provided.