### PR TITLE
Remove useless line from CIRCLE example

### DIFF
--- a/appendix-basic65.tex
+++ b/appendix-basic65.tex
@@ -1962,11 +1962,10 @@ CHDIR "/",U8            :REM GO BACK TO ROOT DIRECTORY
 230 R=RND(.)*36+1                       :REM RADIUS
 240 XC=R+RND(.)*320:IF(XC+R)>319THEN240:REM X CENTRE
 250 YC=R+RND(.)*200:IF(YC+R)>199THEN250:REM Y CENTRE
-260 XC=XC+WT*320:YC=YC+HT*200
-270 CIRCLE XC,YC,R,.                    :REM DRAW
-280 NEXT
-290 GETKEY A$                           :REM WAIT FOR KEY
-300 SCREEN CLOSE:BORDER 6
+260 CIRCLE XC,YC,R,.                    :REM DRAW
+270 NEXT
+280 GETKEY A$                           :REM WAIT FOR KEY
+290 SCREEN CLOSE:BORDER 6
 \end{verbatim}
 \end{tcolorbox}
 \end{description}


### PR DESCRIPTION
`XC=XC+WT*320:YC=YC+HT*200` does nothing because `WT` and `HT` are never set and are thus zero -- making XC=XC and YC=YC.

The history shows that this was left over from a previous revision (which also wasn't right because the variables were named `H` and `W`)