### PR TITLE
Adding information how to control keyboard matrix column 8

### DIFF
--- a/appendix-keyboard.tex
+++ b/appendix-keyboard.tex
@@ -224,7 +224,9 @@ The C65 keyboard matrix layout is as follows:
 }}
 
 Note that the keyboard matrix is identical to the C64 keyboard matrix, except for the addition of one extra column
-on the right-hand side.  The cursor left and up keys on the MEGA65 and C65 are implemented as cursor right and down, but
+on the right-hand side.  While columns 0 to 7 can be controlled via CIA1 just like on the C64, column 8 is controlled
+via I/O port E with its data register at \$D607 and data direction register at \$D608.  Bit 1 of this port controls 
+the extra column 8.  The cursor left and up keys on the MEGA65 and C65 are implemented as cursor right and down, but
 with the right shift key applied.  This enables them to work in C64-mode.  \specialkey{CAPS\\LOCK} is not
 part of the matrix, but has its own dedicated line.  Its status can be read from bit 6 of register \$D611 (decimal 54801):
 


### PR DESCRIPTION
The C65 introduced a ninth keyboard matrix column. As the well-known scanning via CIA1 is now not enough anymore, users need to understand how to control all nine columns now. This information is still lacking in the documentation, which this PR is now addressing.