### PR TITLE
Added missing includes into mega65-book and mega65-chipset-reference

### DIFF
--- a/mega65-book.tex
+++ b/mega65-book.tex
@@ -91,6 +91,8 @@
   \input{appendix-45io27-registers}
   \input{appendix-4541-hw-iec}
   \input{appendix-sound-registers}
+  \input{appendix-rtc-registers}
+  \input{appendix-special-registers}
   \input{appendix-shite}
   \input{appendix-reference-tables}
   \input{appendix-mega65r2-flashing}

--- a/mega65-chipset-reference.tex
+++ b/mega65-chipset-reference.tex
@@ -15,6 +15,8 @@
   \input{appendix-45io27-registers}
   \input{appendix-4541-hw-iec}
   \input{appendix-sound-registers}
+  \input{appendix-rtc-registers}
+  \input{appendix-special-registers}
   \input{appendix-reference-tables}
   \input{appendix-donors}
 


### PR DESCRIPTION
I overlooked the fact that the new section for the RTC clock needed to be added to the mega65-*.tex as well. It was previously only added to the referenceguide.tex (see 7f882964ce) which is not published. 

I would be happy if the new sections would be added to the book and chipset reference as well, if it is considered as useful.

Thanks! :)