### PR TITLE
Minor tweaks for for Q opcodes

### DIFF
--- a/instruction_sets/inst.CMPQ
+++ b/instruction_sets/inst.CMPQ
@@ -9,7 +9,7 @@ little-endian value.
 
 \subsubsection*{Side effects}
 \begin{itemize}
-\item The N flag will be set if the result of A $-$ M is negative, i.e. has it's most significant bit set, otherwise it will be cleared.
-\item The C flag will be set if the result of A $-$ M is zero or positive, i.e., if A is not less than M, otherwise it will be cleared.
-\item The Z flag will be set if the result of A $-$ M is zero, otherwise it will be cleared.
+\item The N flag will be set if the result of Q $-$ M is negative, i.e. has it's most significant bit set, otherwise it will be cleared.
+\item The C flag will be set if the result of Q $-$ M is zero or positive, i.e., if A is not less than M, otherwise it will be cleared.
+\item The Z flag will be set if the result of Q $-$ M is zero, otherwise it will be cleared.
 \end{itemize}

--- a/instruction_sets/inst.ROLQ
+++ b/instruction_sets/inst.ROLQ
@@ -1,5 +1,5 @@
 Rotate Left Quad
-M $\leftarrow$ M$\ll$1, C $\leftarrow$ M(31), M(0) $\leftarrow$ C
+M $\leftarrow$ M$\ll$1, C $\leftarrow$ M(31), M(0) $\leftarrow$ C or Q $\leftarrow$ Q$\ll$1, C $\leftarrow$ Q(31), Q(0) $\leftarrow$ C
 N+Z+C+M+M+
 This instruction shifts either the Q pseudo register or contents
 of the provided memory location one bit left.  Bit 0 will be

--- a/instruction_sets/inst.RORQ
+++ b/instruction_sets/inst.RORQ
@@ -1,5 +1,5 @@
 Rotate Right Quad
-M $\leftarrow$ M$\gg$1, C $\leftarrow$ M(0), M(31) $\leftarrow$ C
+M $\leftarrow$ M$\gg$1, C $\leftarrow$ M(0), M(31) $\leftarrow$ C or Q $\leftarrow$ Q$\gg$1, C $\leftarrow$ Q(0), Q(31) $\leftarrow$ C
 N+Z+C+M+
 This instruction shifts either the Q pseudo register or contents
 of the provided memory location one bit right.  Bit 31 will be

--- a/instruction_sets/inst.SBCQ
+++ b/instruction_sets/inst.SBCQ
@@ -11,10 +11,10 @@ NOTE: If the D flag is set, the operation is undefined and subject to change.
 
 \subsubsection*{Side effects}
 \begin{itemize}
-\item The N flag will be set if the result of A $-$ M is negative, i.e. has it's most significant bit set, otherwise it will be cleared.
-\item The C flag will be set if the result of A $-$ M is zero or positive, i.e., if A is not less than M, otherwise it will be cleared.
+\item The N flag will be set if the result of Q $-$ M is negative, i.e. has it's most significant bit set, otherwise it will be cleared.
+\item The C flag will be set if the result of Q $-$ M is zero or positive, i.e., if A is not less than M, otherwise it will be cleared.
 \item The V flag will be set if the result has a different sign to both of the
 arguments, otherwise it will be cleared. If the flag is set, this
 indicates that a signed overflow has occurred.
-\item The Z flag will be set if the result of A $-$ M is zero, otherwise it will be cleared.
+\item The Z flag will be set if the result of Q $-$ M is zero, otherwise it will be cleared.
 \end{itemize}


### PR DESCRIPTION
Noticed a few minor issues with some of the Q opcodes: 
- The SBCQ, CMPQ opcode during operation referenced A-M instead of Q-M. 
-  The RORQ and ROLQ opcodes on the symbolic operation, did not reflect the Q case. 