### PR TITLE
feat: add make target to build docs using docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+FROM ubuntu:24.04
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+       ca-certificates \
+       git \
+       make \
+       build-essential \
+       pkg-config \
+       gcc \
+       g++ \
+       libssl-dev \
+       libhpdf-dev \
+       ghostscript \
+       inkscape \
+       latexmk \
+       texlive-full \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /work
+
+# Usage (from repo root):
+#   docker build -t mega65-docs .
+#   docker run --rm -v "$PWD":/work -w /work mega65-docs make mega65-book.pdf
+
+

--- a/Makefile
+++ b/Makefile
@@ -282,3 +282,24 @@ realclean: clean
 
 format:
 	find . -iname '*.h' -o -iname '*.c' -o -iname '*.cpp' | xargs clang-format --style=file -i
+
+# -------------------------
+# Docker convenience targets
+# -------------------------
+DOCKER_IMAGE?= mega65-docs
+DOCKER_UID?= $(shell id -u)
+DOCKER_GID?= $(shell id -g)
+
+.PHONY: docker docker-image docker-%
+
+# Build the Docker image with all toolchain dependencies
+docker-image:
+	docker build -t $(DOCKER_IMAGE) .
+
+# Build all PDFs inside Docker
+docker: docker-image
+	docker run --rm -u $(DOCKER_UID):$(DOCKER_GID) -v $(CURDIR):/work -w /work $(DOCKER_IMAGE) bash -lc 'git config --global --add safe.directory /work; make'
+
+# Build a specific PDF inside Docker, e.g. `make docker-mega65-book.pdf`
+docker-%: docker-image
+	docker run --rm -u $(DOCKER_UID):$(DOCKER_GID) -v $(CURDIR):/work -w /work $(DOCKER_IMAGE) bash -lc 'git config --global --add safe.directory /work; make $*'

--- a/README.md
+++ b/README.md
@@ -102,6 +102,35 @@ To delete all LaTeX-built files: `make clean`
 
 To delete every generated file: `make realclean`
 
+# Troubleshooting
+
+If you have trouble building locally (missing LaTeX packages or toolchain):
+
+1. Install Docker.
+2. From the project root, build the Docker image:
+
+```
+make docker-image
+```
+
+3. Build a specific PDF inside Docker (example: the compendium):
+
+```
+make docker-mega65-book.pdf
+```
+
+4. Or build everything inside Docker:
+
+```
+make docker
+```
+
+Notes:
+
+- The Docker image uses a recent Ubuntu base with XeLaTeX and all dependencies.
+- If Git warns about “dubious ownership”, the Docker targets already configure `safe.directory` for `/work` inside the container.
+- Generated PDFs will appear in the project root on your host.
+
 # Editors
 
 ## Visual Studio Code


### PR DESCRIPTION
This PR adds a simple method for building the docs if you are using a machine that can't build due to issues with the packages available for your system.

In my case, Arch has all the wrong versions (ie, the latest of everything) so it fails to build.

I figured people are using Ubuntu to build, so I tried that in a container and it worked first go.